### PR TITLE
Feature/owner permissioning

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-*.sympl python
+*.sympl linguist-language=python

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sympl python

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 .idea
 .DS_Store
+.vscode
+*.pyc
+*.cpython
+test/assembly-sdk-pytest-*

--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ This smart contract repository is a sample "Chat" `symPL` contract. Hereby inclu
 Members includes a role when key is shared via send key operation
 
 - Room channel
-    - Owners: Member
-    - Members: N/A
-    - Dependecies: N/A
+    - Owners: Owners
+    - Members: Members
+    - Dependecies: Owners is a subset of Members
 
 ### Actions
 All `Actions` are write operations on `Channel` that can be done only by `Role`
@@ -26,26 +26,30 @@ All `Actions` are write operations on `Channel` that can be done only by `Role`
 | Action           | Channel | Role    |
 |------------------|---------|---------|
 | Create Room      | Room    | Any     |
-| Delete Room      | Room    | Member  |
-| Restore Room     | Room    | Member  |
-| Invite to Room   | Room    | Member  |
+| Delete Room      | Room    | Owner   |
+| Restore Room     | Room    | Owner   |
+| Invite to Room   | Room    | Owner   |
 | Send Message     | Room    | Member  |
-| Remove from Room | Room    | Member' |
+| Remove from Room | Room    | Owner   |
+| Promote Owner    | Room    | Owner   |
+| Demote Owner     | Room    | Owner   |
 
 ' The member cannot remove itself from the room
- 
+' An owner can, however, demote itself
 ### Events
 All API clients with access to a node containing a `Channel` member have access to `Event Schema` data
 
-| Channel | Event Schema        | Schema Details         |
-|---------|---------------------|------------------------|
-| Room    | CreateRoomEvent     | Room                   |
-| Room	  | DeleteRoomEvent     | Room                   |  
-| Room	  | RestoreRoomEvent    | Room                   | 
-| Room	  | InviteToRoomEvent   | Room, inviter, invitee | 
-| Room 	  | RemoveFromRoomEvent | Room, remover, removee | 
-| Room	  | SendMessageEvent    | Room, message          |
-| Room	  | DeleteRoomEvent     | Room                   |
+| Channel | Event Schema        | Schema Details          |
+|---------|---------------------|-------------------------|
+| Room    | CreateRoomEvent     | Room                    |
+| Room	  | DeleteRoomEvent     | Room                    |  
+| Room	  | RestoreRoomEvent    | Room                    | 
+| Room	  | InviteToRoomEvent   | Room, inviter, invitee  | 
+| Room 	  | RemoveFromRoomEvent | Room, remover, removee  | 
+| Room	  | SendMessageEvent    | Room, message           |
+| Room	  | DeleteRoomEvent     | Room                    |
+| Room    | PromoteOwnerEvent   | Room, promoter, promotee|
+| Room    | DemoteOwnerEvent    | Room, demoter, demotee  |
 
 ## Tests structure
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Members includes a role when key is shared via send key operation
 - Room channel
     - Owners: Owners
     - Members: Members
-    - Dependecies: Owners is a subset of Members
+    - Dependecies: N/A
 
 #### Security Policy of Channel
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,11 @@ Members includes a role when key is shared via send key operation
     - Members: Members
     - Dependecies: Owners is a subset of Members
 
+#### Security Policy of Channel
+
+- `owners` are Channel Owners (added using `cvm.add_owner`)
+- `members` have the Channel Key (received using `cvm.send_key`) 
+- Keys get rotated using `cvm.rotate_key` when an `owner` of a `room` removes someone from the room.
 ### Actions
 All `Actions` are write operations on `Channel` that can be done only by `Role`
 
@@ -31,7 +36,7 @@ All `Actions` are write operations on `Channel` that can be done only by `Role`
 | Invite to Room   | Room    | Owner   |
 | Send Message     | Room    | Member  |
 | Remove from Room | Room    | Owner   |
-| Promote Owner    | Room    | Owner   |
+| Promote to Owner | Room    | Owner   |
 | Demote Owner     | Room    | Owner   |
 
 ' The member cannot remove itself from the room

--- a/chat.sympl
+++ b/chat.sympl
@@ -88,7 +88,7 @@ schema RemoveFromRoomEvent:
 
 schema SendMessageEvent:
     room: Room
-    message: Message
+    mid: Identifier
 
 schema PromoteToOwnerEvent:
     room: Room
@@ -215,10 +215,9 @@ def _create_room(room_name: str) -> None:
     room_channel = cvm.new_channel('RID')
     with PostTxArgs(room_channel):
         _create_room_execute(room_name, room_channel)
-    cvm.job_start()
 
 @executable
-def _create_room_execute(room_name: str, room_channel: ChannelName) -> None:
+def _create_room_execute(room_name: str, room_channel: ChannelName) -> CreateRoomEvent:
     _guard_input("Room name", room_name)
     room = cvm.storage.get(room_channel, RoomStatic, Identifier('room'))
     if isinstance(room, None):
@@ -226,7 +225,7 @@ def _create_room_execute(room_name: str, room_channel: ChannelName) -> None:
         cvm.storage.put(Identifier('room'), room)
         create_room_event = CreateRoomEvent(room=room)
         cvm.create_event('CreateRoomEvent', std.json(create_room_event))
-        cvm.job_complete(std.json(create_room_event))
+        return create_room_event
     else:
         room_channel_str : str = room_channel
         cvm.error(f'Room {room_channel_str} already exists.')
@@ -240,7 +239,6 @@ def _delete_room(room_channel: ChannelName) -> None:
 
     with PostTxArgs(room_channel):
         _delete_room_execute(room_channel)
-    cvm.job_start()
 
 @executable
 def _delete_room_execute(room_channel: ChannelName) -> DeleteRoomEvent:
@@ -278,7 +276,6 @@ def _restore_room(room_channel: ChannelName) -> None:
 
     with PostTxArgs(room_channel):
         _restore_room_execute(room_channel)
-    cvm.job_start()
 
 @executable
 def _restore_room_execute(room_channel: ChannelName) -> RestoreRoomEvent:
@@ -319,7 +316,6 @@ def _invite_to_room(room_channel: ChannelName, new_member: KeyAlias) -> None:
     cvm.send_key(room_channel, new_member)
     with PostTxArgs(room_channel):
         _invite_to_room_execute(room_channel, new_member)
-    cvm.job_start()
 
 
 @executable
@@ -431,11 +427,10 @@ def _send_message(room_channel: ChannelName, message: str) -> None:
     _guard_input("Message", message)
     with PostTxArgs(room_channel):
         _send_message_execute(room_channel, message)
-    cvm.job_start()
 
 
 @executable
-def _send_message_execute(room_channel: ChannelName, message: str) -> None:
+def _send_message_execute(room_channel: ChannelName, message: str) -> SendMessageEvent:
     room = _get_room(room_channel)
     members = room.members
 
@@ -450,9 +445,10 @@ def _send_message_execute(room_channel: ChannelName, message: str) -> None:
     message_id = cvm.generate_id('MID')
     new_message = Message(message_id=message_id, sender=cvm.tx.key_alias, body=message, timestamp=cvm.tx.timestamp)
     cvm.storage.put(new_message.message_id, new_message)
-    send_message_event = SendMessageEvent(room=room, message=new_message)
-    cvm.create_event('SendMessageEvent', std.json(message_id))
-    cvm.job_complete(std.json(message_id))
+    
+    send_message_event = SendMessageEvent(room=room, mid=message_id)
+    cvm.create_event('SendMessageEvent', std.json(send_message_event))
+    return send_message_event
 
 @public_clientside
 def _get_messages(room_channel: ChannelName) -> List[Message]:

--- a/chat.sympl
+++ b/chat.sympl
@@ -284,10 +284,6 @@ def _invite_to_room_execute(room_channel: ChannelName, new_member: KeyAlias) -> 
         not_a_member : str = cvm.tx.key_alias
         cvm.error(f'Member {not_a_member} does not belong to the room. Operation denied.')
 
-    if not std.contains_using(members, cvm.tx.key_alias, _str_eq):
-            not_a_member : str = cvm.tx.key_alias
-            cvm.error(f'Member {not_a_member} does not belong to the room. Operation denied.')
-
     room.members = room.members + [new_member]
     cvm.storage.put(Identifier('room'), room)
     invite_to_room_event = InviteToRoomEvent(room=room, inviter=cvm.tx.key_alias, invitee=new_member)

--- a/chat.sympl
+++ b/chat.sympl
@@ -31,6 +31,19 @@
 # contract module has isolated storage associated with it, used to store the shared state associated with the logic of the
 # module.
 
+# The general structure of the actions that occur in this contract looks like the following:
+#
+# For each action, there is a @clientside and @executable function. Each @clientside function has 
+# a @clientside_helper function, and each action contains a "checker" function. The checker functions
+# gatekeep actions. For example, in this chat contract, only users who are a 'member' of a room are allowed
+# to send messages to that room. This is checked in send_message_checks. The reason for designating a dedicated
+# function for these checks is to also be able to use it in @executable functions. The checks in the @clientside_helper
+# functions are gatekeeping to prevent sending usless transactions to the blockchain, and the checks in the @executable
+# functions are to prevent transactions that do reach the blockchain from executing if they shouldn't
+
+# The calling sequence of actions would look like this
+# @clientside -> @clientside_helper -> @helper checks -> @executable -> @helper checks
+
 # Copyright © 2019 Symbiont.io, all rights reserved.
 
 # Proprietary and confidential. Unauthorized copying via any medium is strictly prohibited.
@@ -189,9 +202,15 @@ def demote_owner(room_channel: ChannelName, owner: KeyAlias) -> None:
 # # # implementations #
 # # ###################
 
+# the helper 'decorator' here is used to put the cvm functions
+# in scope into this function
+# the reason there's no associated @executable function
+# is because you don't need to run code across the blockchain
+# in order to simply read information
 @helper
 def _get_room(room_channel: ChannelName) -> Room:
     room = cvm.storage.get(room_channel, RoomStatic, Identifier('room'))
+    #check if the room exists
     if isinstance(room,  None):
         room_channel_str : str = room_channel
         cvm.error(f"Room for channel {room_channel_str} not found.")
@@ -211,6 +230,9 @@ def _guard_input(input_description: str, input_: str) -> None:
 
 @clientside_helper
 def _create_room(room_name: str) -> None:
+    #this function will run checks on the propsed
+    #room name and cvm.error if there are issues
+    #cvm.error will end the transaction
     _guard_input("Room name", room_name)
     room_channel = cvm.new_channel('RID')
     with PostTxArgs(room_channel):
@@ -220,6 +242,7 @@ def _create_room(room_name: str) -> None:
 def _create_room_execute(room_name: str, room_channel: ChannelName) -> CreateRoomEvent:
     _guard_input("Room name", room_name)
     room = cvm.storage.get(room_channel, RoomStatic, Identifier('room'))
+    #check if the room exists already. The storage query will return None if the room doesn't exist
     if isinstance(room, None):
         room = Room(channel=room_channel, name=room_name, is_deleted=False, members=[cvm.tx.key_alias], owners=[cvm.tx.key_alias])
         cvm.storage.put(Identifier('room'), room)
@@ -247,8 +270,11 @@ def _delete_room_execute(room_channel: ChannelName) -> DeleteRoomEvent:
     #run the checks on delete room
     delete_room_checks(room_channel)
 
+    #modify contract storage
     room.is_deleted = True
     cvm.storage.put(Identifier('room'), room)
+
+    #create a restore room event
     delete_room_event = DeleteRoomEvent(room=room)
     cvm.create_event('DeleteRoomEvent', std.json(delete_room_event))
     return delete_room_event
@@ -285,8 +311,11 @@ def _restore_room_execute(room_channel: ChannelName) -> RestoreRoomEvent:
     #run the checks for restore room
     restore_room_checks(room_channel)
 
+    #modify contract storage
     room.is_deleted = False
     cvm.storage.put(Identifier('room'), room)
+
+    #create a restore room event
     restore_room_event = RestoreRoomEvent(room=room)
     cvm.create_event('RestoreRoomEvent', std.json(restore_room_event))
     return restore_room_event
@@ -310,13 +339,12 @@ def _invite_to_room(room_channel: ChannelName, new_member: KeyAlias) -> None:
     room = _get_room(room_channel)
 
     #perform invite checks
-    invite_to_room_checks(room, new_member, cvm.tx.key_alias)
+    invite_to_room_checks(room, new_member)
 
     #cvm.add_owner(room_channel, new_member)
     cvm.send_key(room_channel, new_member)
     with PostTxArgs(room_channel):
         _invite_to_room_execute(room_channel, new_member)
-
 
 @executable
 def _invite_to_room_execute(room_channel: ChannelName, new_member: KeyAlias) -> InviteToRoomEvent:
@@ -324,19 +352,22 @@ def _invite_to_room_execute(room_channel: ChannelName, new_member: KeyAlias) -> 
     members = room.members
 
     #perform invite checks
-    invite_to_room_checks(room, new_member, cvm.tx.key_alias)
+    invite_to_room_checks(room, new_member)
     
+    #modify contract storage
     room.members = room.members + [new_member]
     cvm.storage.put(Identifier('room'), room)
 
+    #creates an invite to room event
     invite_to_room_event = InviteToRoomEvent(room=room, inviter=cvm.tx.key_alias, invitee=new_member)
     cvm.create_event('InviteToRoomEvent', std.json(invite_to_room_event))
     return invite_to_room_event
 
 #runs checks to see if the caller has the correct permissions to invite the 
-#a new member to a room, returns '' if there are no issues
+#a new member to a room
 @helper
-def invite_to_room_checks(room: Room, new_member: KeyAlias, caller: KeyAlias) -> None:
+def invite_to_room_checks(room: Room, new_member: KeyAlias) -> None:
+    caller : KeyAlias = cvm.tx.key_alias
 
     #check if the caller is an owner
     if not std.contains_using(room.owners, caller, _str_eq):
@@ -349,27 +380,6 @@ def invite_to_room_checks(room: Room, new_member: KeyAlias, caller: KeyAlias) ->
     #check if the room is deleted
     if room.is_deleted:
         cvm.error(f"{room.channel} is deleted.")
-
-
-@clientside_helper
-#runs checks to see if the caller has the correct permissions to invite the 
-#a new member to a room, returns '' if there are no issues
-def invite_to_room_checks(room: Room, new_member: KeyAlias, caller: KeyAlias) -> str:
-
-    #check if the caller is an owner
-    if not std.contains_using(room.owners, caller, _str_eq):
-        return f"{caller} is not an owner of the room {room.channel}"
-
-    #check if the invitee is already a member
-    if std.contains_using(room.members, new_member, _str_eq):
-        return f"{new_member} is already a member of the room {room.channel}"
-
-    #check if the room is deleted
-    if room.is_deleted:
-        return f"{room.channel} is deleted."
-
-    return ''
-
 
 @clientside_helper
 def _remove_from_room(room_channel: ChannelName, member_to_remove: KeyAlias) -> None:
@@ -386,6 +396,9 @@ def _remove_from_room(room_channel: ChannelName, member_to_remove: KeyAlias) -> 
     with PostTxArgs(room_channel):
         _remove_from_room_execute(room_channel, member_to_remove)
 
+    #rotate the keys so that all members of the chatroom will be able to 
+    #read future messages, and the member we are removing will not be able to 
+    #read future messages
     cvm.rotate_key(room_channel)
     for member in room.members:
         mx : str = member
@@ -440,17 +453,30 @@ def remove_from_room_checks(room: Room, member_to_remove: KeyAlias, caller: KeyA
 
 @clientside_helper
 def _send_message(room_channel: ChannelName, message: str) -> None:
-    room = _get_room(room_channel)
-    if room.is_deleted:
-        room_channel_str : str = room_channel
-        cvm.error(f'Room {room_channel_str} has been deleted. Cannot send message.')
-    _guard_input("Message", message)
+    
+    #run checks on sending the message
+    send_message_checks(room_channel, message)
+
     with PostTxArgs(room_channel):
         _send_message_execute(room_channel, message)
 
-
 @executable
 def _send_message_execute(room_channel: ChannelName, message: str) -> SendMessageEvent:
+    room = _get_room(room_channel)
+
+    #run checks on sending the message
+    send_message_checks(room_channel, message)
+
+    message_id = cvm.generate_id('MID')
+    new_message = Message(message_id=message_id, sender=cvm.tx.key_alias, body=message, timestamp=cvm.tx.timestamp)
+    cvm.storage.put(new_message.message_id, new_message)
+    
+    send_message_event = SendMessageEvent(room=room, mid=message_id)
+    cvm.create_event('SendMessageEvent', std.json(send_message_event))
+    return send_message_event
+
+@helper
+def send_message_checks(room_channel: ChannelName, message: str) -> None:
     room = _get_room(room_channel)
     members = room.members
 
@@ -461,14 +487,8 @@ def _send_message_execute(room_channel: ChannelName, message: str) -> SendMessag
     if room.is_deleted:
         room_channel_str : str = room_channel
         cvm.error(f'Room {room_channel_str} has been deleted. Cannot send message.')
+
     _guard_input("Message", message)
-    message_id = cvm.generate_id('MID')
-    new_message = Message(message_id=message_id, sender=cvm.tx.key_alias, body=message, timestamp=cvm.tx.timestamp)
-    cvm.storage.put(new_message.message_id, new_message)
-    
-    send_message_event = SendMessageEvent(room=room, mid=message_id)
-    cvm.create_event('SendMessageEvent', std.json(send_message_event))
-    return send_message_event
 
 @clientside_helper
 def _get_messages(room_channel: ChannelName) -> List[Message]:
@@ -572,7 +592,6 @@ def _demote_owner(room_channel: ChannelName, owner: KeyAlias) -> None:
 
     #run demote checks
     demote_owner_checks(owner, cvm.tx.key_alias, room)
-
     
     #if there's only one owner left when you attempt to demote an owner
     #promote the next member (that is not a current owner) to owner

--- a/chat.sympl
+++ b/chat.sympl
@@ -310,7 +310,13 @@ def _invite_to_room(room_channel: ChannelName, new_member: KeyAlias) -> None:
     room = _get_room(room_channel)
 
     #perform invite checks
+<<<<<<< HEAD
     invite_to_room_checks(room, new_member, cvm.tx.key_alias)
+=======
+    check_result : str = invite_to_room_checks(room, new_member, cvm.tx.key_alias)
+    if check_result != '':
+        cvm.error(check_result)
+>>>>>>> 7af94d1 (modified invite and remove to handle owners)
 
     #cvm.add_owner(room_channel, new_member)
     cvm.send_key(room_channel, new_member)
@@ -324,7 +330,13 @@ def _invite_to_room_execute(room_channel: ChannelName, new_member: KeyAlias) -> 
     members = room.members
 
     #perform invite checks
+<<<<<<< HEAD
     invite_to_room_checks(room, new_member, cvm.tx.key_alias)
+=======
+    check_result : str = invite_to_room_checks(room, new_member, cvm.tx.key_alias)
+    if check_result != '':
+        cvm.error(check_result)
+>>>>>>> 7af94d1 (modified invite and remove to handle owners)
     
     room.members = room.members + [new_member]
     cvm.storage.put(Identifier('room'), room)
@@ -352,10 +364,36 @@ def invite_to_room_checks(room: Room, new_member: KeyAlias, caller: KeyAlias) ->
 
 
 @clientside_helper
+#runs checks to see if the caller has the correct permissions to invite the 
+#a new member to a room, returns '' if there are no issues
+def invite_to_room_checks(room: Room, new_member: KeyAlias, caller: KeyAlias) -> str:
+
+    #check if the caller is an owner
+    if not std.contains_using(room.owners, caller, _str_eq):
+        return f"{caller} is not an owner of the room {room.channel}"
+
+    #check if the invitee is already a member
+    if std.contains_using(room.members, new_member, _str_eq):
+        return f"{new_member} is already a member of the room {room.channel}"
+
+    #check if the room is deleted
+    if room.is_deleted:
+        return f"{room.channel} is deleted."
+
+    return ''
+
+
+@public_clientside
 def _remove_from_room(room_channel: ChannelName, member_to_remove: KeyAlias) -> None:
     room = _get_room(room_channel)
     #run checks on removing
+<<<<<<< HEAD
     remove_from_room_checks(room, member_to_remove, cvm.tx.key_alias)
+=======
+    checks_result = remove_from_room_checks(room, member_to_remove, cvm.tx.key_alias)
+    if checks_result != '':
+        cvm.error(checks_result)
+>>>>>>> 7af94d1 (modified invite and remove to handle owners)
 
     #if the member to remove is an owner, we want to remove ownership
     #privileges, and then promote a new owner if there are no
@@ -378,8 +416,14 @@ def _remove_from_room_execute(room_channel: ChannelName, member_to_remove: KeyAl
     members = room.members
 
     #run checks on removing
+<<<<<<< HEAD
     remove_from_room_checks(room, member_to_remove, cvm.tx.key_alias)
   
+=======
+    checks_result = remove_from_room_checks(room, member_to_remove, cvm.tx.key_alias)
+    if checks_result != '':
+        cvm.error(checks_result)    
+>>>>>>> 7af94d1 (modified invite and remove to handle owners)
 
     # room.members-remove(member_to_remove)
     mtr: str = member_to_remove
@@ -394,6 +438,7 @@ def _remove_from_room_execute(room_channel: ChannelName, member_to_remove: KeyAl
 
 #runs checks to see if the caller has the correct permissions to invite the 
 #a new member to a room, returns '' if there are no issues
+<<<<<<< HEAD
 @public
 def remove_from_room_checks(room: Room, member_to_remove: KeyAlias, caller: KeyAlias) -> None:
     #check if caller is an owner and has perms to remove 
@@ -405,6 +450,21 @@ def remove_from_room_checks(room: Room, member_to_remove: KeyAlias, caller: KeyA
     #check if the room is deleted
     if room.is_deleted:
         cvm.error(f"Room {room.channel} is deleted! Operation Denied.")
+=======
+def remove_from_room_checks(room: Room, member_to_remove: KeyAlias, caller: KeyAlias) -> str:
+    #check if caller is an owner and has perms to remove 
+    if (not std.contains_using(room.owners, caller, _str_eq)): # and (str(member_to_remove) != str(caller)):
+        return f"{caller} is not an owner and does not have permission to remove {member_to_remove} from room {room}" 
+    #check if member to remove is actually a member of the room
+    if not std.contains_using(room.members, member_to_remove, _str_eq):
+        return f"{member_to_remove} is not a member of room {room.channel}. Operation Denied."
+    #check if there will be people left in the room once member_to_remove leaves
+    if len(room.members) == 1:
+        return f"Cannot leave a room empty. Please delete the room if you want to get rid of it!"
+    #check if the room is deleted
+    if room.is_deleted:
+        return f"Room {room.channel} is not deleted! Operation Denied."
+>>>>>>> 7af94d1 (modified invite and remove to handle owners)
 
     #check if caller is the same as the person to remove... cannot remove yourself
     #### - this is the case because when someone leaves the secure channel, the keys
@@ -416,7 +476,13 @@ def remove_from_room_checks(room: Room, member_to_remove: KeyAlias, caller: KeyA
     mtr_str : str = member_to_remove
     cal_str : str = caller
     if mtr_str == cal_str:
+<<<<<<< HEAD
         cvm.error(f"Cannot remove self from room.")
+=======
+        return f"Cannot remove yourself from the room!"
+
+    return ''
+>>>>>>> 7af94d1 (modified invite and remove to handle owners)
 
 @clientside_helper
 def _send_message(room_channel: ChannelName, message: str) -> None:
@@ -551,8 +617,14 @@ def _demote_owner(room_channel: ChannelName, owner: KeyAlias) -> None:
     room = _get_room(room_channel)
 
     #run demote checks
+<<<<<<< HEAD
     demote_owner_checks(owner, cvm.tx.key_alias, room)
 
+=======
+    check_result : str = demote_owner_checks(owner, cvm.tx.key_alias, room)
+    if check_result != '':
+        cvm.error(check_result)
+>>>>>>> 7af94d1 (modified invite and remove to handle owners)
     
     #if there's only one owner left when you attempt to demote an owner
     #promote the next member (that is not a current owner) to owner
@@ -582,7 +654,13 @@ def _demote_owner(room_channel: ChannelName, owner: KeyAlias) -> None:
 def _demote_owner_execute(room_channel: ChannelName, owner: KeyAlias) -> DemoteOwnerEvent:
     room = _get_room(room_channel)
 
+<<<<<<< HEAD
     demote_owner_checks(owner, cvm.tx.key_alias, room)
+=======
+    check_result : str = demote_owner_checks(owner, cvm.tx.key_alias, room)
+    if check_result != '':
+        cvm.error(check_result)
+>>>>>>> 7af94d1 (modified invite and remove to handle owners)
 
     #update the owners list in storage
     otr : str = owner
@@ -618,12 +696,30 @@ def demote_owner_checks(owner: KeyAlias, caller: KeyAlias, room: Room) -> None:
     if not std.contains_using(room.owners, owner, _str_eq):
         owner_str : str = owner
         room_channel_str : str = room_channel
+<<<<<<< HEAD
         cvm.error(f'{owner_str} is not an owner of room {room_channel_str}. Cannot demote a non-owner')
+=======
+        return f'{owner_str} is not an owner of room {room_channel_str}. Cannot demote a non-owner'
+>>>>>>> 7af94d1 (modified invite and remove to handle owners)
     
     #check to ensure that a room is not deleted
     if room.is_deleted:
         room_channel_str : str = room_channel
+<<<<<<< HEAD
         cvm.error(f'Room {room_channel_str} has been deleted. Cannot demote anyone')
+=======
+        return f'Room {room_channel_str} has been deleted. Cannot promote anyone'
+
+    #ensure that the calling key alias is an owner of the room, and is allowed
+    #to demote others from owner
+    if not std.contains_using(room.owners, caller, _str_eq):
+        not_an_owner : str = caller
+        return f'{not_an_owner} is not an owner of the room. Operation denied.'
+    
+    #cannot leave zero owners in the room
+    if len(room.owners) == 1 and len(room.members) == 1:
+        return f"Cannot demote {owner}, as {owner} is the only member!"
+>>>>>>> 7af94d1 (modified invite and remove to handle owners)
 
     #cannot leave zero owners in the room
     if len(room.owners) == 1 and len(room.members) == 1:

--- a/chat.sympl
+++ b/chat.sympl
@@ -467,10 +467,15 @@ def _send_message_execute(room_channel: ChannelName, message: str) -> SendMessag
     #run checks on sending the message
     send_message_checks(room_channel, message)
 
+    # create a message
     message_id = cvm.generate_id('MID')
     new_message = Message(message_id=message_id, sender=cvm.tx.key_alias, body=message, timestamp=cvm.tx.timestamp)
     cvm.storage.put(new_message.message_id, new_message)
     
+    # create an event saying there's a new message
+    # Note: the send_message_event doesn't store the contents of 
+    # the message. This was done because it would allow anyone on
+    # the blockchain network to read the contents of the message
     send_message_event = SendMessageEvent(room=room, mid=message_id)
     cvm.create_event('SendMessageEvent', std.json(send_message_event))
     return send_message_event

--- a/chat.sympl
+++ b/chat.sympl
@@ -101,7 +101,7 @@ schema RemoveFromRoomEvent:
 
 schema SendMessageEvent:
     room: Room
-    mid: Identifier
+    message_id: Identifier
 
 schema PromoteToOwnerEvent:
     room: Room
@@ -371,7 +371,7 @@ def invite_to_room_checks(room: Room, new_member: KeyAlias) -> None:
 
     #check if the caller is an owner
     if not std.contains_using(room.owners, caller, _str_eq):
-        cvm.error(f"{caller} is not an owner of the room {room.channel}")
+        cvm.error(f"{caller} is not an owner of the room {room.channel}.")
 
     #check if the invitee is already a member
     if std.contains_using(room.members, new_member, _str_eq):
@@ -431,7 +431,7 @@ def _remove_from_room_execute(room_channel: ChannelName, member_to_remove: KeyAl
 def remove_from_room_checks(room: Room, member_to_remove: KeyAlias, caller: KeyAlias) -> None:
     #check if caller is an owner and has perms to remove 
     if (not std.contains_using(room.owners, caller, _str_eq)): # and (str(member_to_remove) != str(caller)):
-        cvm.error(f"{caller} is not an owner and does not have permission to remove {member_to_remove} from room {room.channel}" )
+        cvm.error(f"{caller} is not an owner and does not have permission to remove {member_to_remove} from room {room.channel}." )
     #check if member to remove is actually a member of the room
     if not std.contains_using(room.members, member_to_remove, _str_eq):
         cvm.error(f"Member {member_to_remove} not in room {room.channel}.")
@@ -476,7 +476,7 @@ def _send_message_execute(room_channel: ChannelName, message: str) -> SendMessag
     # Note: the send_message_event doesn't store the contents of 
     # the message. This was done because it would allow anyone on
     # the blockchain network to read the contents of the message
-    send_message_event = SendMessageEvent(room=room, mid=message_id)
+    send_message_event = SendMessageEvent(room=room, message_id=message_id)
     cvm.create_event('SendMessageEvent', std.json(send_message_event))
     return send_message_event
 
@@ -582,7 +582,7 @@ def promote_to_owner_checks(member: KeyAlias, caller: KeyAlias, room: Room) -> N
     #check to ensure that a room is not deleted
     if room.is_deleted:
         room_channel_str : str = room_channel
-        cvm.error( f'Room {room_channel_str} has been deleted. Cannot promote anyone')
+        cvm.error( f'Room {room_channel_str} has been deleted. Cannot promote.')
 
     #ensure that the calling key alias is an owner of the room, and is allowed
     #to promote others to owner
@@ -662,12 +662,12 @@ def demote_owner_checks(owner: KeyAlias, caller: KeyAlias, room: Room) -> None:
     if not std.contains_using(room.owners, owner, _str_eq):
         owner_str : str = owner
         room_channel_str : str = room_channel
-        cvm.error(f'{owner_str} is not an owner of room {room_channel_str}. Cannot demote a non-owner')
+        cvm.error(f'{owner_str} is not an owner of room {room_channel_str}. Cannot demote a non-owner.')
     
     #check to ensure that a room is not deleted
     if room.is_deleted:
         room_channel_str : str = room_channel
-        cvm.error(f'Room {room_channel_str} has been deleted. Cannot demote anyone')
+        cvm.error(f'Room {room_channel_str} has been deleted. Cannot demote.')
 
     #cannot leave zero owners in the room
     if len(room.owners) == 1 and len(room.members) == 1:

--- a/chat.sympl
+++ b/chat.sympl
@@ -260,7 +260,7 @@ def _delete_room_execute(room_channel: ChannelName) -> DeleteRoomEvent:
     cvm.create_event('DeleteRoomEvent', std.json(delete_room_event))
     return delete_room_event
 
-@public
+@helper
 def delete_room_checks(room_channel: ChannelName) -> None:
     room = _get_room(room_channel)
 
@@ -305,7 +305,7 @@ def _restore_room_execute(room_channel: ChannelName) -> RestoreRoomEvent:
     cvm.create_event('RestoreRoomEvent', std.json(restore_room_event))
     return restore_room_event
 
-@public
+@helper
 def restore_room_checks(room_channel: ChannelName) -> None:
     room = _get_room(room_channel)
 
@@ -391,7 +391,7 @@ def invite_to_room_checks(room: Room, new_member: KeyAlias, caller: KeyAlias) ->
 @clientside_helper
 #runs checks to see if the caller has the correct permissions to invite the 
 #a new member to a room, returns '' if there are no issues
-@public
+@helper
 def invite_to_room_checks(room: Room, new_member: KeyAlias, caller: KeyAlias) -> None:
 
     #check if the caller is an owner
@@ -411,7 +411,7 @@ def invite_to_room_checks(room: Room, new_member: KeyAlias, caller: KeyAlias) ->
         cvm.error(f"{room.channel} is deleted.")
 
 
-@public_clientside
+@clientside_helper
 def _remove_from_room(room_channel: ChannelName, member_to_remove: KeyAlias) -> None:
     room = _get_room(room_channel)
     #run checks on removing
@@ -477,6 +477,7 @@ def _remove_from_room_execute(room_channel: ChannelName, member_to_remove: KeyAl
 #a new member to a room, returns '' if there are no issues
 <<<<<<< HEAD
 <<<<<<< HEAD
+<<<<<<< HEAD
 @public
 def remove_from_room_checks(room: Room, member_to_remove: KeyAlias, caller: KeyAlias) -> None:
     #check if caller is an owner and has perms to remove 
@@ -505,6 +506,9 @@ def remove_from_room_checks(room: Room, member_to_remove: KeyAlias, caller: KeyA
 >>>>>>> 7af94d1 (modified invite and remove to handle owners)
 =======
 @public
+=======
+@helper
+>>>>>>> 529113f (use helper instead of public)
 def remove_from_room_checks(room: Room, member_to_remove: KeyAlias, caller: KeyAlias) -> None:
     #check if caller is an owner and has perms to remove 
     if (not std.contains_using(room.owners, caller, _str_eq)): # and (str(member_to_remove) != str(caller)):
@@ -600,7 +604,7 @@ def _get_rooms() -> List[Room]:
 
     return std.sort_by(rooms, compare)
 
-@public_clientside
+@clientside_helper
 def _promote_to_owner(room_channel: ChannelName, member: KeyAlias) -> None:
     room = _get_room(room_channel)
     
@@ -635,7 +639,7 @@ def _promote_to_owner_execute(room_channel: ChannelName, member: KeyAlias) -> Pr
     cvm.create_event('PromoteToOwnerEvent', std.json(promote_to_owner_event))
     return promote_to_owner_event
 
-@public
+@helper
 def promote_to_owner_checks(member: KeyAlias, caller: KeyAlias, room: Room) -> None:
     #This function performs the permission checks for the promote to owner logic
     #it takes a member, caller, and a room channel, and ensures that the caller KA
@@ -666,7 +670,7 @@ def promote_to_owner_checks(member: KeyAlias, caller: KeyAlias, room: Room) -> N
         not_an_owner : str = caller
         cvm.error( f'{not_an_owner} is not an owner of the room. Operation denied.')
 
-@public_clientside
+@clientside_helper
 def _demote_owner(room_channel: ChannelName, owner: KeyAlias) -> None:
     
     room = _get_room(room_channel)
@@ -737,7 +741,7 @@ def _demote_owner_execute(room_channel: ChannelName, owner: KeyAlias) -> DemoteO
     cvm.create_event('DemoteOwnerEvent', std.json(demote_owner_event))
     return demote_owner_event
 
-@public
+@helper
 def demote_owner_checks(owner: KeyAlias, caller: KeyAlias, room: Room) -> None:
     #This function performs the permission checks for the demote owner logic
     #it takes an owner, caller, and a room channel, and ensures that the caller KA

--- a/chat.sympl
+++ b/chat.sympl
@@ -240,9 +240,12 @@ def _delete_room(room_channel: ChannelName) -> None:
     with PostTxArgs(room_channel):
         _delete_room_execute(room_channel)
 <<<<<<< HEAD
+<<<<<<< HEAD
 =======
     cvm.job_start()
 >>>>>>> 942c14e (more tests/now use @public)
+=======
+>>>>>>> fef5799 (removed job start and job complete)
 
 @executable
 def _delete_room_execute(room_channel: ChannelName) -> DeleteRoomEvent:
@@ -281,9 +284,12 @@ def _restore_room(room_channel: ChannelName) -> None:
     with PostTxArgs(room_channel):
         _restore_room_execute(room_channel)
 <<<<<<< HEAD
+<<<<<<< HEAD
 =======
     cvm.job_start()
 >>>>>>> 942c14e (more tests/now use @public)
+=======
+>>>>>>> fef5799 (removed job start and job complete)
 
 @executable
 def _restore_room_execute(room_channel: ChannelName) -> RestoreRoomEvent:

--- a/chat.sympl
+++ b/chat.sympl
@@ -234,66 +234,86 @@ def _create_room_execute(room_name: str, room_channel: ChannelName) -> None:
 @public_clientside
 def _delete_room(room_channel: ChannelName) -> None:
     room = _get_room(room_channel)
-    if room.is_deleted:
-        room_channel_str : str = room_channel
-        cvm.error(f'Room {room_channel_str} already deleted.')
+
+    #delete the checks on the room
+    delete_room_checks(room_channel)
+
     with PostTxArgs(room_channel):
         _delete_room_execute(room_channel)
     cvm.job_start()
 
-
 @executable
-def _delete_room_execute(room_channel: ChannelName) -> None:
+def _delete_room_execute(room_channel: ChannelName) -> DeleteRoomEvent:
     room = _get_room(room_channel)
-    members = room.members
 
-    if not std.contains_using(members, cvm.tx.key_alias, _str_eq):
-        not_a_member : str = cvm.tx.key_alias
-        cvm.error(f'Member {not_a_member} does not belong to the room. Operation denied.')
+    #run the checks on delete room
+    delete_room_checks(room_channel)
 
     room.is_deleted = True
     cvm.storage.put(Identifier('room'), room)
     delete_room_event = DeleteRoomEvent(room=room)
     cvm.create_event('DeleteRoomEvent', std.json(delete_room_event))
-    cvm.job_complete(std.json(delete_room_event))
+    return delete_room_event
+
+@public
+def delete_room_checks(room_channel: ChannelName) -> None:
+    room = _get_room(room_channel)
+
+    if room.is_deleted:
+        room_channel_str : str = room_channel
+        cvm.error(f'Room {room_channel_str} already deleted.')
+    if not std.contains_using(room.members, cvm.tx.key_alias, _str_eq):
+        not_a_member : str = cvm.tx.key_alias
+        cvm.error(f'Member {not_a_member} does not belong to the room. Operation denied.')
+    if not std.contains_using(room.owners, cvm.tx.key_alias, _str_eq):
+        not_an_owner: str = cvm.tx.key_alias
+        cvm.error(f"{not_an_owner} is not an owner and does not have permission to delete the room.")
 
 @public_clientside
 def _restore_room(room_channel: ChannelName) -> None:
     room = _get_room(room_channel)
-    if not room.is_deleted:
-        room_channel_str : str = room_channel
-        cvm.error(f'Room {room_channel_str} already active.')
+    
+    #run the checks for restore room
+    restore_room_checks(room_channel)
+
     with PostTxArgs(room_channel):
         _restore_room_execute(room_channel)
     cvm.job_start()
 
-
 @executable
-def _restore_room_execute(room_channel: ChannelName) -> None:
+def _restore_room_execute(room_channel: ChannelName) -> RestoreRoomEvent:
     room = _get_room(room_channel)
     members = room.members
 
-    if not std.contains_using(members, cvm.tx.key_alias, _str_eq):
-        not_a_member : str = cvm.tx.key_alias
-        cvm.error(f'Member {not_a_member} does not belong to the room. Operation denied.')
+    #run the checks for restore room
+    restore_room_checks(room_channel)
 
-    if not room.is_deleted:
-        room_channel_str : str = room_channel
-        cvm.error(f'Room {room_channel_str} already active.')
     room.is_deleted = False
     cvm.storage.put(Identifier('room'), room)
     restore_room_event = RestoreRoomEvent(room=room)
     cvm.create_event('RestoreRoomEvent', std.json(restore_room_event))
-    cvm.job_complete(std.json(restore_room_event))
+    return restore_room_event
+
+@public
+def restore_room_checks(room_channel: ChannelName) -> None:
+    room = _get_room(room_channel)
+
+    if not room.is_deleted:
+        room_channel_str : str = room_channel
+        cvm.error(f'Room {room_channel_str} already active.')
+    if not std.contains_using(room.members, cvm.tx.key_alias, _str_eq):
+        not_a_member : str = cvm.tx.key_alias
+        cvm.error(f'Member {not_a_member} does not belong to the room. Operation denied.')
+    if not std.contains_using(room.owners, cvm.tx.key_alias, _str_eq):
+        not_an_owner: str = cvm.tx.key_alias
+        cvm.error(f"{not_an_owner} is not an owner and does not have permission to delete the room.")
 
 @public_clientside
 def _invite_to_room(room_channel: ChannelName, new_member: KeyAlias) -> None:
     room = _get_room(room_channel)
 
     #perform invite checks
-    check_result : str = invite_to_room_checks(room, new_member, cvm.tx.key_alias)
-    if check_result != '':
-        cvm.error(check_result)
+    invite_to_room_checks(room, new_member, cvm.tx.key_alias)
 
     #cvm.add_owner(room_channel, new_member)
     cvm.send_key(room_channel, new_member)
@@ -303,47 +323,43 @@ def _invite_to_room(room_channel: ChannelName, new_member: KeyAlias) -> None:
 
 
 @executable
-def _invite_to_room_execute(room_channel: ChannelName, new_member: KeyAlias) -> None:
+def _invite_to_room_execute(room_channel: ChannelName, new_member: KeyAlias) -> InviteToRoomEvent:
     room = _get_room(room_channel)
     members = room.members
 
     #perform invite checks
-    check_result : str = invite_to_room_checks(room, new_member, cvm.tx.key_alias)
-    if check_result != '':
-        cvm.error(check_result)
+    invite_to_room_checks(room, new_member, cvm.tx.key_alias)
     
     room.members = room.members + [new_member]
     cvm.storage.put(Identifier('room'), room)
+
     invite_to_room_event = InviteToRoomEvent(room=room, inviter=cvm.tx.key_alias, invitee=new_member)
     cvm.create_event('InviteToRoomEvent', std.json(invite_to_room_event))
-    cvm.job_complete(std.json(invite_to_room_event))
+    return invite_to_room_event
 
 #runs checks to see if the caller has the correct permissions to invite the 
 #a new member to a room, returns '' if there are no issues
-def invite_to_room_checks(room: Room, new_member: KeyAlias, caller: KeyAlias) -> str:
+@public
+def invite_to_room_checks(room: Room, new_member: KeyAlias, caller: KeyAlias) -> None:
 
     #check if the caller is an owner
     if not std.contains_using(room.owners, caller, _str_eq):
-        return f"{caller} is not an owner of the room {room.channel}"
+        cvm.error(f"{caller} is not an owner of the room {room.channel}")
 
     #check if the invitee is already a member
     if std.contains_using(room.members, new_member, _str_eq):
-        return f"Member {new_member} already in room {room.channel}."
+        cvm.error(f"Member {new_member} already in room {room.channel}.")
 
     #check if the room is deleted
     if room.is_deleted:
-        return f"{room.channel} is deleted."
-
-    return ''
+        cvm.error(f"{room.channel} is deleted.")
 
 
 @public_clientside
 def _remove_from_room(room_channel: ChannelName, member_to_remove: KeyAlias) -> None:
     room = _get_room(room_channel)
     #run checks on removing
-    checks_result = remove_from_room_checks(room, member_to_remove, cvm.tx.key_alias)
-    if checks_result != '':
-        cvm.error(checks_result)
+    remove_from_room_checks(room, member_to_remove, cvm.tx.key_alias)
 
     #if the member to remove is an owner, we want to remove ownership
     #privileges, and then promote a new owner if there are no
@@ -366,9 +382,8 @@ def _remove_from_room_execute(room_channel: ChannelName, member_to_remove: KeyAl
     members = room.members
 
     #run checks on removing
-    checks_result = remove_from_room_checks(room, member_to_remove, cvm.tx.key_alias)
-    if checks_result != '':
-        cvm.error(checks_result)    
+    remove_from_room_checks(room, member_to_remove, cvm.tx.key_alias)
+  
 
     # room.members-remove(member_to_remove)
     mtr: str = member_to_remove
@@ -377,21 +392,23 @@ def _remove_from_room_execute(room_channel: ChannelName, member_to_remove: KeyAl
 
     cvm.storage.put(Identifier('room'), room)
     remove_from_room_event = RemoveFromRoomEvent(room=room, remover=cvm.tx.key_alias, removee=member_to_remove)
+    
     cvm.create_event('RemoveFromRoomEvent', std.json(remove_from_room_event))
     return remove_from_room_event
 
 #runs checks to see if the caller has the correct permissions to invite the 
 #a new member to a room, returns '' if there are no issues
-def remove_from_room_checks(room: Room, member_to_remove: KeyAlias, caller: KeyAlias) -> str:
+@public
+def remove_from_room_checks(room: Room, member_to_remove: KeyAlias, caller: KeyAlias) -> None:
     #check if caller is an owner and has perms to remove 
     if (not std.contains_using(room.owners, caller, _str_eq)): # and (str(member_to_remove) != str(caller)):
-        return f"{caller} is not an owner and does not have permission to remove {member_to_remove} from room {room.channel}" 
+        cvm.error(f"{caller} is not an owner and does not have permission to remove {member_to_remove} from room {room.channel}" )
     #check if member to remove is actually a member of the room
     if not std.contains_using(room.members, member_to_remove, _str_eq):
-        return f"Member {member_to_remove} not in room {room.channel}."
+        cvm.error(f"Member {member_to_remove} not in room {room.channel}.")
     #check if the room is deleted
     if room.is_deleted:
-        return f"Room {room.channel} is not deleted! Operation Denied."
+        cvm.error(f"Room {room.channel} is deleted! Operation Denied.")
 
     #check if caller is the same as the person to remove... cannot remove yourself
     #### - this is the case because when someone leaves the secure channel, the keys
@@ -403,9 +420,7 @@ def remove_from_room_checks(room: Room, member_to_remove: KeyAlias, caller: KeyA
     mtr_str : str = member_to_remove
     cal_str : str = caller
     if mtr_str == cal_str:
-        return f"Cannot remove self from room."
-
-    return ''
+        cvm.error(f"Cannot remove self from room.")
 
 @public_clientside
 def _send_message(room_channel: ChannelName, message: str) -> None:
@@ -473,9 +488,7 @@ def _promote_to_owner(room_channel: ChannelName, member: KeyAlias) -> None:
     room = _get_room(room_channel)
     
     #run the checks and error out if there is an issue
-    check_result: str = promote_to_owner_checks(member, cvm.tx.key_alias, room)
-    if check_result != '':
-        cvm.error(check_result)
+    promote_to_owner_checks(member, cvm.tx.key_alias, room)
 
     #This will promote the member to 'owner' of the secure channel
     cvm.add_owner(room_channel, member)
@@ -494,9 +507,7 @@ def _promote_to_owner_execute(room_channel: ChannelName, member: KeyAlias) -> Pr
     #this is performed on both the executable and clientside sides
     #because a malicious KA and Node Administrator could directly run
     #any executable function 
-    check_result: str = promote_to_owner_checks(member, cvm.tx.key_alias, room)
-    if check_result != '':
-        cvm.error(check_result)
+    promote_to_owner_checks(member, cvm.tx.key_alias, room)
 
     #update the owners list in storage
     room.owners = room.owners + [member]
@@ -507,7 +518,8 @@ def _promote_to_owner_execute(room_channel: ChannelName, member: KeyAlias) -> Pr
     cvm.create_event('PromoteToOwnerEvent', std.json(promote_to_owner_event))
     return promote_to_owner_event
 
-def promote_to_owner_checks(member: KeyAlias, caller: KeyAlias, room: Room) -> str:
+@public
+def promote_to_owner_checks(member: KeyAlias, caller: KeyAlias, room: Room) -> None:
     #This function performs the permission checks for the promote to owner logic
     #it takes a member, caller, and a room channel, and ensures that the caller KA
     #is allowed to promote the member KA to an owner
@@ -518,26 +530,24 @@ def promote_to_owner_checks(member: KeyAlias, caller: KeyAlias, room: Room) -> s
     if not std.contains_using(room.members, member, _str_eq):
         member_str : str = member
         room_channel_str : str = room_channel
-        return f"Member {member_str} is not in room {room_channel_str}."
+        cvm.error( f"Member {member_str} is not in room {room_channel_str}.")
     
     #check to ensure a member is not already an owner
     if std.contains_using(room.owners, member, _str_eq):
         member_str : str = member
         room_channel_str : str = room_channel
-        return f"Member {member_str} is already an owner of room {room_channel_str}."
+        cvm.error( f"Member {member_str} is already an owner of room {room_channel_str}.")
 
     #check to ensure that a room is not deleted
     if room.is_deleted:
         room_channel_str : str = room_channel
-        return f'Room {room_channel_str} has been deleted. Cannot promote anyone'
+        cvm.error( f'Room {room_channel_str} has been deleted. Cannot promote anyone')
 
     #ensure that the calling key alias is an owner of the room, and is allowed
     #to promote others to owner
     if not std.contains_using(room.owners, caller, _str_eq):
         not_an_owner : str = caller
-        return f'{not_an_owner} is not an owner of the room. Operation denied.'
-    
-    return ''
+        cvm.error( f'{not_an_owner} is not an owner of the room. Operation denied.')
 
 @public_clientside
 def _demote_owner(room_channel: ChannelName, owner: KeyAlias) -> None:
@@ -545,9 +555,8 @@ def _demote_owner(room_channel: ChannelName, owner: KeyAlias) -> None:
     room = _get_room(room_channel)
 
     #run demote checks
-    check_result : str = demote_owner_checks(owner, cvm.tx.key_alias, room)
-    if check_result != '':
-        cvm.error(check_result)
+    demote_owner_checks(owner, cvm.tx.key_alias, room)
+
     
     #if there's only one owner left when you attempt to demote an owner
     #promote the next member (that is not a current owner) to owner
@@ -577,9 +586,7 @@ def _demote_owner(room_channel: ChannelName, owner: KeyAlias) -> None:
 def _demote_owner_execute(room_channel: ChannelName, owner: KeyAlias) -> DemoteOwnerEvent:
     room = _get_room(room_channel)
 
-    check_result : str = demote_owner_checks(owner, cvm.tx.key_alias, room)
-    if check_result != '':
-        cvm.error(check_result)
+    demote_owner_checks(owner, cvm.tx.key_alias, room)
 
     #update the owners list in storage
     otr : str = owner
@@ -592,7 +599,8 @@ def _demote_owner_execute(room_channel: ChannelName, owner: KeyAlias) -> DemoteO
     cvm.create_event('DemoteOwnerEvent', std.json(demote_owner_event))
     return demote_owner_event
 
-def demote_owner_checks(owner: KeyAlias, caller: KeyAlias, room: Room) -> str:
+@public
+def demote_owner_checks(owner: KeyAlias, caller: KeyAlias, room: Room) -> None:
     #This function performs the permission checks for the demote owner logic
     #it takes an owner, caller, and a room channel, and ensures that the caller KA
     #is allowed to demote the owner KA
@@ -602,30 +610,28 @@ def demote_owner_checks(owner: KeyAlias, caller: KeyAlias, room: Room) -> str:
     if not std.contains_using(room.members, owner, _str_eq):
         owner_str : str = owner
         room_channel_str : str = room_channel
-        return f'{owner_str} is not a member of room {room_channel_str}. Please invite them first.'
-
-    #check to ensure the owner to demote is actually an owner
-    if not std.contains_using(room.owners, owner, _str_eq):
-        owner_str : str = owner
-        room_channel_str : str = room_channel
-        return f'{owner_str} is not an owner of room {room_channel_str}. Cannot demote a non-owner'
-    
-    #check to ensure that a room is not deleted
-    if room.is_deleted:
-        room_channel_str : str = room_channel
-        return f'Room {room_channel_str} has been deleted. Cannot promote anyone'
+        cvm.error(f'{owner_str} is not a member of room {room_channel_str}.')
 
     #ensure that the calling key alias is an owner of the room, and is allowed
     #to demote others from owner
     if not std.contains_using(room.owners, caller, _str_eq):
         not_an_owner : str = caller
-        return f'{not_an_owner} is not an owner of the room. Operation denied.'
+        cvm.error(f'{not_an_owner} is not an owner of the room. Operation denied.')
+
+    #check to ensure the owner to demote is actually an owner
+    if not std.contains_using(room.owners, owner, _str_eq):
+        owner_str : str = owner
+        room_channel_str : str = room_channel
+        cvm.error(f'{owner_str} is not an owner of room {room_channel_str}. Cannot demote a non-owner')
     
+    #check to ensure that a room is not deleted
+    if room.is_deleted:
+        room_channel_str : str = room_channel
+        cvm.error(f'Room {room_channel_str} has been deleted. Cannot demote anyone')
+
     #cannot leave zero owners in the room
     if len(room.owners) == 1 and len(room.members) == 1:
-        return f"Cannot demote {owner}, as {owner} is the only member!"
-
-    return ""
+        cvm.error(f"Cannot demote {owner}, as {owner} is the only member!")
 
 def _str_eq(str1 : str, str2: str) -> bool:
     return str1 == str2

--- a/chat.sympl
+++ b/chat.sympl
@@ -389,9 +389,6 @@ def remove_from_room_checks(room: Room, member_to_remove: KeyAlias, caller: KeyA
     #check if member to remove is actually a member of the room
     if not std.contains_using(room.members, member_to_remove, _str_eq):
         return f"{member_to_remove} is not a member of room {room.channel}. Operation Denied."
-    #check if there will be people left in the room once member_to_remove leaves
-    if len(room.members) == 1:
-        return f"Cannot leave a room empty. Please delete the room if you want to get rid of it!"
     #check if the room is deleted
     if room.is_deleted:
         return f"Room {room.channel} is not deleted! Operation Denied."
@@ -406,7 +403,7 @@ def remove_from_room_checks(room: Room, member_to_remove: KeyAlias, caller: KeyA
     mtr_str : str = member_to_remove
     cal_str : str = caller
     if mtr_str == cal_str:
-        return f"Cannot remove yourself from the room!"
+        return f"Cannot remove self from room!"
 
     return ''
 

--- a/chat.sympl
+++ b/chat.sympl
@@ -189,7 +189,7 @@ def demote_owner(room_channel: ChannelName, owner: KeyAlias) -> None:
 # # # implementations #
 # # ###################
 
-@public
+@helper
 def _get_room(room_channel: ChannelName) -> Room:
     room = cvm.storage.get(room_channel, RoomStatic, Identifier('room'))
     if isinstance(room,  None):
@@ -197,7 +197,7 @@ def _get_room(room_channel: ChannelName) -> Room:
         cvm.error(f"Room for channel {room_channel_str} not found.")
     return room
 
-@public
+@helper
 def _guard_input(input_description: str, input_: str) -> None:
     if input_ == '':
         cvm.error(f"{input_description} cannot be empty.")
@@ -209,7 +209,7 @@ def _guard_input(input_description: str, input_: str) -> None:
     if len(input_) > 4000:
         cvm.error(f"{input_description} cannot be longer than 4000 characters.")
 
-@public_clientside
+@clientside_helper
 def _create_room(room_name: str) -> None:
     _guard_input("Room name", room_name)
     room_channel = cvm.new_channel('RID')
@@ -230,7 +230,7 @@ def _create_room_execute(room_name: str, room_channel: ChannelName) -> CreateRoo
         room_channel_str : str = room_channel
         cvm.error(f'Room {room_channel_str} already exists.')
 
-@public_clientside
+@clientside_helper
 def _delete_room(room_channel: ChannelName) -> None:
     room = _get_room(room_channel)
 
@@ -267,7 +267,7 @@ def delete_room_checks(room_channel: ChannelName) -> None:
         not_an_owner: str = cvm.tx.key_alias
         cvm.error(f"{not_an_owner} is not an owner and does not have permission to delete the room.")
 
-@public_clientside
+@clientside_helper
 def _restore_room(room_channel: ChannelName) -> None:
     room = _get_room(room_channel)
     
@@ -305,7 +305,7 @@ def restore_room_checks(room_channel: ChannelName) -> None:
         not_an_owner: str = cvm.tx.key_alias
         cvm.error(f"{not_an_owner} is not an owner and does not have permission to delete the room.")
 
-@public_clientside
+@clientside_helper
 def _invite_to_room(room_channel: ChannelName, new_member: KeyAlias) -> None:
     room = _get_room(room_channel)
 
@@ -351,7 +351,7 @@ def invite_to_room_checks(room: Room, new_member: KeyAlias, caller: KeyAlias) ->
         cvm.error(f"{room.channel} is deleted.")
 
 
-@public_clientside
+@clientside_helper
 def _remove_from_room(room_channel: ChannelName, member_to_remove: KeyAlias) -> None:
     room = _get_room(room_channel)
     #run checks on removing
@@ -418,7 +418,7 @@ def remove_from_room_checks(room: Room, member_to_remove: KeyAlias, caller: KeyA
     if mtr_str == cal_str:
         cvm.error(f"Cannot remove self from room.")
 
-@public_clientside
+@clientside_helper
 def _send_message(room_channel: ChannelName, message: str) -> None:
     room = _get_room(room_channel)
     if room.is_deleted:
@@ -450,7 +450,7 @@ def _send_message_execute(room_channel: ChannelName, message: str) -> SendMessag
     cvm.create_event('SendMessageEvent', std.json(send_message_event))
     return send_message_event
 
-@public_clientside
+@clientside_helper
 def _get_messages(room_channel: ChannelName) -> List[Message]:
     # check that the room exists and is accessible
     room = _get_room(room_channel)
@@ -464,7 +464,7 @@ def _get_messages(room_channel: ChannelName) -> List[Message]:
         return lt < rhs.timestamp
     return std.sort_by(messages, compare)
 
-@public
+@helper
 def _get_rooms() -> List[Room]:
     rooms : List[Room] = [r for r in cvm.storage.query(RoomStatic).values() if not r.is_deleted]
     def compare(lhs: Room, rhs: Room) -> bool:

--- a/chat.sympl
+++ b/chat.sympl
@@ -61,6 +61,7 @@ schema Room:
     name: str  # the human-readable name of the room
     is_deleted: bool  # to support restoration, deleted rooms are flagged, not expunged
     members: List[KeyAlias]  # a list of the key aliases that have access to the room
+    owners: List[KeyAlias]   # a list of key aliases that are 'owners' of the room (this should always be a subset of 'members', these people functiona as admins)
 
 ##########
 # events #
@@ -88,6 +89,16 @@ schema RemoveFromRoomEvent:
 schema SendMessageEvent:
     room: Room
     message: Message
+
+schema PromoteToOwnerEvent:
+    room: Room
+    promoter: KeyAlias
+    promotee: KeyAlias
+
+schema DemoteOwnerEvent:
+    room: Room
+    demoter: KeyAlias
+    demotee: KeyAlias
 
 # ##############
 # # public API #
@@ -131,7 +142,7 @@ def remove_from_room(room_channel: ChannelName, member_to_remove: KeyAlias) -> N
     """Removes a member from a room.
     A removed member will no longer be able to send or receive messages, add or remove members, nor delete or restore
     the room.
-    A member cannot remove themselves.
+    A member cannot remove themselves if they are the last one in the room.
     """
     return _remove_from_room(room_channel, member_to_remove)
 
@@ -158,6 +169,20 @@ def send_message(room_channel: ChannelName, message: str) -> None:
     """
     return _send_message(room_channel, message)
 
+
+@clientside
+def promote_to_owner(room_channel: ChannelName, member: KeyAlias) -> None:
+    """Promotes a current member of a room to owner
+    Promotions to owner of the room 
+    """
+    return _promote_to_owner(room_channel, member)
+
+@clientside
+def demote_owner(room_channel: ChannelName, owner: KeyAlias) -> None:
+    """Demotes the owner of a room.
+    Only works if there is at least one other owner
+    """
+    return None
 
 # # ###################
 # # # implementations #
@@ -191,13 +216,12 @@ def _create_room(room_name: str) -> None:
         _create_room_execute(room_name, room_channel)
     cvm.job_start()
 
-
 @executable
 def _create_room_execute(room_name: str, room_channel: ChannelName) -> None:
     _guard_input("Room name", room_name)
     room = cvm.storage.get(room_channel, RoomStatic, Identifier('room'))
     if isinstance(room, None):
-        room = Room(channel=room_channel, name=room_name, is_deleted=False, members=[cvm.tx.key_alias])
+        room = Room(channel=room_channel, name=room_name, is_deleted=False, members=[cvm.tx.key_alias], owners=[cvm.tx.key_alias])
         cvm.storage.put(Identifier('room'), room)
         create_room_event = CreateRoomEvent(room=room)
         cvm.create_event('CreateRoomEvent', std.json(create_room_event))
@@ -269,7 +293,8 @@ def _invite_to_room(room_channel: ChannelName, new_member: KeyAlias) -> None:
         new_member_str : str = new_member
         room_channel_str : str = room_channel
         cvm.error(f'Member {new_member_str} already in room {room_channel_str}.')
-    cvm.add_owner(room_channel, new_member)
+    #cvm.add_owner(room_channel, new_member)
+    cvm.send_key(room_channel, new_member)
     with PostTxArgs(room_channel):
         _invite_to_room_execute(room_channel, new_member)
     cvm.job_start()
@@ -303,7 +328,7 @@ def _remove_from_room(room_channel: ChannelName, member_to_remove: KeyAlias) -> 
         cvm.error(f'Member {member_to_remove_str} not in room {room_channel_str}.')
     with PostTxArgs(room_channel):
         _remove_from_room_execute(room_channel, member_to_remove)
-    cvm.remove_owner(room_channel, member_to_remove)
+    #cvm.remove_owner(room_channel, member_to_remove)
     cvm.rotate_key(room_channel)
     updated_members = room.members
     for member in updated_members:
@@ -397,6 +422,137 @@ def _get_rooms() -> List[Room]:
 
     return std.sort_by(rooms, compare)
 
+@public_clientside
+def _promote_to_owner(room_channel: ChannelName, member: KeyAlias) -> None:
+    room = _get_room(room_channel)
+    
+    #run the checks and error out if there is an issue
+    check_result: str = promote_to_owner_checks(member, cvm.tx.key_alias, room)
+    if check_result != '':
+        cvm.error(check_result)
+
+    #This will promote the member to 'owner' of the secure channel
+    cvm.add_owner(room_channel, member)
+
+    #This function allows the @executable function
+    #to have access the the channel with which you
+    #are attempting to write
+    with PostTxArgs(room_channel):
+        _promote_to_owner_execute(room_channel, member)
+
+@executable
+def _promote_to_owner_execute(room_channel: ChannelName, member: KeyAlias) -> str:
+    room = _get_room(room_channel)
+    
+    #run the checks, and error out if there is an issue
+    #this is performed on both the executable and clientside sides
+    #because a malicious KA and Node Administrator could directly run
+    #any executable function 
+    check_result: str = promote_to_owner_checks(member, cvm.tx.key_alias, room)
+    if check_result != '':
+        cvm.error(check_result)
+
+    #update the owners list in storage
+    room.owners = room.owners + [member]
+    cvm.storage.put(Identifier('room'), room)
+
+    #create an event for owner promotion, and return the json string
+    promote_to_owner_event = PromoteToOwnerEvent(room=room, promoter=cvm.tx.key_alias, promotee=member)
+    cvm.create_event('PromoteToOwnerEvent', std.json(promote_to_owner_event))
+    return std.json_to_str(std.json(promote_to_owner_event))
+
+def promote_to_owner_checks(member: KeyAlias, caller: KeyAlias, room: Room) -> str:
+    #This function performs the permission checks for the promote to owner logic
+    #it takes a member, caller, and a room channel, and ensures that the caller KA
+    #is allowed to promote the member KA to an owner
+
+    room_channel = room.channel
+
+    #ensure that the member to promote is actually in the room
+    if not std.contains_using(room.members, member, _str_eq):
+        member_str : str = member
+        room_channel_str : str = room_channel
+        return f"Member {member_str} is not in room {room_channel_str}."
+    
+    #check to ensure a member is not already an owner
+    if std.contains_using(room.owners, member, _str_eq):
+        member_str : str = member
+        room_channel_str : str = room_channel
+        return f"Member {member_str} is already an owner of room {room_channel_str}."
+
+    #check to ensure that a room is not deleted
+    if room.is_deleted:
+        room_channel_str : str = room_channel
+        return f'Room {room_channel_str} has been deleted. Cannot promote anyone'
+
+    #ensure that the calling key alias is an owner of the room, and is allowed
+    #to promote others to owner
+    if not std.contains_using(room.owners, caller, _str_eq):
+        not_an_owner : str = caller
+        return f'{not_an_owner} is not an owner of the room. Operation denied.'
+    
+    return ''
+
+@public_clientside
+def _demote_owner(room_channel: ChannelName, owner: KeyAlias) -> None:
+    #Clientside check to make sure that the member to demote is actually
+    #an owner
+    room = _get_room(room_channel)
+
+    #This will remove the 'owner' from the secure channel
+    cvm.remove_owner(room_channel, owner)
+    
+    #This function allows the @executable function
+    #to have access the the channel with which you
+    #are attempting to write
+    with PostTxArgs(room_channel):
+        _demote_owner_execute(room_channel, owner)
+
+@executable
+def _demote_owner_execute(room_channel: ChannelName, owner: KeyAlias) -> str:
+    room = _get_room(room_channel)
+    
+    #update the owners list in storage
+    otr : str = owner
+    new_owners_list : List[KeyAlias] = [o for o in room.owners if otr != o]
+    room.owners = new_owners_list
+    cvm.storage.put(Identifier('room'), room)
+
+    #create an event for owner promotion, and return the json string
+    demote_owner_event = DemoteOwnerEvent(room=room, demoter=cvm.tx.key_alias, demotee=owner)
+    cvm.create_event('DemoteOwnerEvent', std.json(demote_owner_event))
+    return std.json_to_str(std.json(demote_owner_event))
+
+def demote_owner_checks(owner: KeyAlias, caller: KeyAlias, room: Room) -> str:
+    #This function performs the permission checks for the demote owner logic
+    #it takes an owner, caller, and a room channel, and ensures that the caller KA
+    #is allowed to demote the owner KA
+    room_channel =  room.channel
+    
+    #check to ensure the owner is already a member of a room
+    if not std.contains_using(room.members, owner, _str_eq):
+        owner_str : str = owner
+        room_channel_str : str = room_channel
+        return f'{owner_str} is not a member of room {room_channel_str}. Please invite them first.'
+
+    #check to ensure the new owner is not already an owner
+    if std.contains_using(room.owners, owner, _str_eq):
+        owner_str : str = owner
+        room_channel_str : str = room_channel
+        return f'{owner_str} is already an owner of room {room_channel_str}.'
+    
+    #check to ensure that a room is not deleted
+    if room.is_deleted:
+        room_channel_str : str = room_channel
+        return f'Room {room_channel_str} has been deleted. Cannot promote anyone'
+
+    #ensure that the calling key alias is an owner of the room, and is allowed
+    #to promote others to owner
+    if not std.contains_using(room.owners, caller, _str_eq):
+        not_an_owner : str = caller
+        return f'{not_an_owner} is not an owner of the room. Operation denied.'
+
+    return ""
 
 def _str_eq(str1 : str, str2: str) -> bool:
     return str1 == str2

--- a/chat.sympl
+++ b/chat.sympl
@@ -239,13 +239,6 @@ def _delete_room(room_channel: ChannelName) -> None:
 
     with PostTxArgs(room_channel):
         _delete_room_execute(room_channel)
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
-    cvm.job_start()
->>>>>>> 942c14e (more tests/now use @public)
-=======
->>>>>>> fef5799 (removed job start and job complete)
 
 @executable
 def _delete_room_execute(room_channel: ChannelName) -> DeleteRoomEvent:
@@ -283,13 +276,6 @@ def _restore_room(room_channel: ChannelName) -> None:
 
     with PostTxArgs(room_channel):
         _restore_room_execute(room_channel)
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
-    cvm.job_start()
->>>>>>> 942c14e (more tests/now use @public)
-=======
->>>>>>> fef5799 (removed job start and job complete)
 
 @executable
 def _restore_room_execute(room_channel: ChannelName) -> RestoreRoomEvent:
@@ -324,17 +310,7 @@ def _invite_to_room(room_channel: ChannelName, new_member: KeyAlias) -> None:
     room = _get_room(room_channel)
 
     #perform invite checks
-<<<<<<< HEAD
-<<<<<<< HEAD
     invite_to_room_checks(room, new_member, cvm.tx.key_alias)
-=======
-    check_result : str = invite_to_room_checks(room, new_member, cvm.tx.key_alias)
-    if check_result != '':
-        cvm.error(check_result)
->>>>>>> 7af94d1 (modified invite and remove to handle owners)
-=======
-    invite_to_room_checks(room, new_member, cvm.tx.key_alias)
->>>>>>> 942c14e (more tests/now use @public)
 
     #cvm.add_owner(room_channel, new_member)
     cvm.send_key(room_channel, new_member)
@@ -348,17 +324,7 @@ def _invite_to_room_execute(room_channel: ChannelName, new_member: KeyAlias) -> 
     members = room.members
 
     #perform invite checks
-<<<<<<< HEAD
-<<<<<<< HEAD
     invite_to_room_checks(room, new_member, cvm.tx.key_alias)
-=======
-    check_result : str = invite_to_room_checks(room, new_member, cvm.tx.key_alias)
-    if check_result != '':
-        cvm.error(check_result)
->>>>>>> 7af94d1 (modified invite and remove to handle owners)
-=======
-    invite_to_room_checks(room, new_member, cvm.tx.key_alias)
->>>>>>> 942c14e (more tests/now use @public)
     
     room.members = room.members + [new_member]
     cvm.storage.put(Identifier('room'), room)
@@ -366,29 +332,7 @@ def _invite_to_room_execute(room_channel: ChannelName, new_member: KeyAlias) -> 
     invite_to_room_event = InviteToRoomEvent(room=room, inviter=cvm.tx.key_alias, invitee=new_member)
     cvm.create_event('InviteToRoomEvent', std.json(invite_to_room_event))
     return invite_to_room_event
-<<<<<<< HEAD
 
-#runs checks to see if the caller has the correct permissions to invite the 
-#a new member to a room, returns '' if there are no issues
-@public
-def invite_to_room_checks(room: Room, new_member: KeyAlias, caller: KeyAlias) -> None:
-
-    #check if the caller is an owner
-    if not std.contains_using(room.owners, caller, _str_eq):
-        cvm.error(f"{caller} is not an owner of the room {room.channel}")
-
-    #check if the invitee is already a member
-    if std.contains_using(room.members, new_member, _str_eq):
-        cvm.error(f"Member {new_member} already in room {room.channel}.")
-
-    #check if the room is deleted
-    if room.is_deleted:
-        cvm.error(f"{room.channel} is deleted.")
-
-=======
->>>>>>> 942c14e (more tests/now use @public)
-
-@clientside_helper
 #runs checks to see if the caller has the correct permissions to invite the 
 #a new member to a room, returns '' if there are no issues
 @helper
@@ -400,11 +344,7 @@ def invite_to_room_checks(room: Room, new_member: KeyAlias, caller: KeyAlias) ->
 
     #check if the invitee is already a member
     if std.contains_using(room.members, new_member, _str_eq):
-<<<<<<< HEAD
-        return f"{new_member} is already a member of the room {room.channel}"
-=======
         cvm.error(f"Member {new_member} already in room {room.channel}.")
->>>>>>> 942c14e (more tests/now use @public)
 
     #check if the room is deleted
     if room.is_deleted:
@@ -412,20 +352,30 @@ def invite_to_room_checks(room: Room, new_member: KeyAlias, caller: KeyAlias) ->
 
 
 @clientside_helper
+#runs checks to see if the caller has the correct permissions to invite the 
+#a new member to a room, returns '' if there are no issues
+def invite_to_room_checks(room: Room, new_member: KeyAlias, caller: KeyAlias) -> str:
+
+    #check if the caller is an owner
+    if not std.contains_using(room.owners, caller, _str_eq):
+        return f"{caller} is not an owner of the room {room.channel}"
+
+    #check if the invitee is already a member
+    if std.contains_using(room.members, new_member, _str_eq):
+        return f"{new_member} is already a member of the room {room.channel}"
+
+    #check if the room is deleted
+    if room.is_deleted:
+        return f"{room.channel} is deleted."
+
+    return ''
+
+
+@clientside_helper
 def _remove_from_room(room_channel: ChannelName, member_to_remove: KeyAlias) -> None:
     room = _get_room(room_channel)
     #run checks on removing
-<<<<<<< HEAD
-<<<<<<< HEAD
     remove_from_room_checks(room, member_to_remove, cvm.tx.key_alias)
-=======
-    checks_result = remove_from_room_checks(room, member_to_remove, cvm.tx.key_alias)
-    if checks_result != '':
-        cvm.error(checks_result)
->>>>>>> 7af94d1 (modified invite and remove to handle owners)
-=======
-    remove_from_room_checks(room, member_to_remove, cvm.tx.key_alias)
->>>>>>> 942c14e (more tests/now use @public)
 
     #if the member to remove is an owner, we want to remove ownership
     #privileges, and then promote a new owner if there are no
@@ -448,19 +398,8 @@ def _remove_from_room_execute(room_channel: ChannelName, member_to_remove: KeyAl
     members = room.members
 
     #run checks on removing
-<<<<<<< HEAD
-<<<<<<< HEAD
     remove_from_room_checks(room, member_to_remove, cvm.tx.key_alias)
   
-=======
-    checks_result = remove_from_room_checks(room, member_to_remove, cvm.tx.key_alias)
-    if checks_result != '':
-        cvm.error(checks_result)    
->>>>>>> 7af94d1 (modified invite and remove to handle owners)
-=======
-    remove_from_room_checks(room, member_to_remove, cvm.tx.key_alias)
-  
->>>>>>> 942c14e (more tests/now use @public)
 
     # room.members-remove(member_to_remove)
     mtr: str = member_to_remove
@@ -475,40 +414,7 @@ def _remove_from_room_execute(room_channel: ChannelName, member_to_remove: KeyAl
 
 #runs checks to see if the caller has the correct permissions to invite the 
 #a new member to a room, returns '' if there are no issues
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-@public
-def remove_from_room_checks(room: Room, member_to_remove: KeyAlias, caller: KeyAlias) -> None:
-    #check if caller is an owner and has perms to remove 
-    if (not std.contains_using(room.owners, caller, _str_eq)): # and (str(member_to_remove) != str(caller)):
-        cvm.error(f"{caller} is not an owner and does not have permission to remove {member_to_remove} from room {room.channel}" )
-    #check if member to remove is actually a member of the room
-    if not std.contains_using(room.members, member_to_remove, _str_eq):
-        cvm.error(f"Member {member_to_remove} not in room {room.channel}.")
-    #check if the room is deleted
-    if room.is_deleted:
-        cvm.error(f"Room {room.channel} is deleted! Operation Denied.")
-=======
-def remove_from_room_checks(room: Room, member_to_remove: KeyAlias, caller: KeyAlias) -> str:
-    #check if caller is an owner and has perms to remove 
-    if (not std.contains_using(room.owners, caller, _str_eq)): # and (str(member_to_remove) != str(caller)):
-        return f"{caller} is not an owner and does not have permission to remove {member_to_remove} from room {room}" 
-    #check if member to remove is actually a member of the room
-    if not std.contains_using(room.members, member_to_remove, _str_eq):
-        return f"{member_to_remove} is not a member of room {room.channel}. Operation Denied."
-    #check if there will be people left in the room once member_to_remove leaves
-    if len(room.members) == 1:
-        return f"Cannot leave a room empty. Please delete the room if you want to get rid of it!"
-    #check if the room is deleted
-    if room.is_deleted:
-        return f"Room {room.channel} is not deleted! Operation Denied."
->>>>>>> 7af94d1 (modified invite and remove to handle owners)
-=======
-@public
-=======
 @helper
->>>>>>> 529113f (use helper instead of public)
 def remove_from_room_checks(room: Room, member_to_remove: KeyAlias, caller: KeyAlias) -> None:
     #check if caller is an owner and has perms to remove 
     if (not std.contains_using(room.owners, caller, _str_eq)): # and (str(member_to_remove) != str(caller)):
@@ -519,7 +425,6 @@ def remove_from_room_checks(room: Room, member_to_remove: KeyAlias, caller: KeyA
     #check if the room is deleted
     if room.is_deleted:
         cvm.error(f"Room {room.channel} is deleted! Operation Denied.")
->>>>>>> 942c14e (more tests/now use @public)
 
     #check if caller is the same as the person to remove... cannot remove yourself
     #### - this is the case because when someone leaves the secure channel, the keys
@@ -531,17 +436,7 @@ def remove_from_room_checks(room: Room, member_to_remove: KeyAlias, caller: KeyA
     mtr_str : str = member_to_remove
     cal_str : str = caller
     if mtr_str == cal_str:
-<<<<<<< HEAD
-<<<<<<< HEAD
         cvm.error(f"Cannot remove self from room.")
-=======
-        return f"Cannot remove yourself from the room!"
-
-    return ''
->>>>>>> 7af94d1 (modified invite and remove to handle owners)
-=======
-        cvm.error(f"Cannot remove self from room.")
->>>>>>> 942c14e (more tests/now use @public)
 
 @clientside_helper
 def _send_message(room_channel: ChannelName, message: str) -> None:
@@ -676,19 +571,8 @@ def _demote_owner(room_channel: ChannelName, owner: KeyAlias) -> None:
     room = _get_room(room_channel)
 
     #run demote checks
-<<<<<<< HEAD
-<<<<<<< HEAD
     demote_owner_checks(owner, cvm.tx.key_alias, room)
 
-=======
-    check_result : str = demote_owner_checks(owner, cvm.tx.key_alias, room)
-    if check_result != '':
-        cvm.error(check_result)
->>>>>>> 7af94d1 (modified invite and remove to handle owners)
-=======
-    demote_owner_checks(owner, cvm.tx.key_alias, room)
-
->>>>>>> 942c14e (more tests/now use @public)
     
     #if there's only one owner left when you attempt to demote an owner
     #promote the next member (that is not a current owner) to owner
@@ -718,17 +602,7 @@ def _demote_owner(room_channel: ChannelName, owner: KeyAlias) -> None:
 def _demote_owner_execute(room_channel: ChannelName, owner: KeyAlias) -> DemoteOwnerEvent:
     room = _get_room(room_channel)
 
-<<<<<<< HEAD
-<<<<<<< HEAD
     demote_owner_checks(owner, cvm.tx.key_alias, room)
-=======
-    check_result : str = demote_owner_checks(owner, cvm.tx.key_alias, room)
-    if check_result != '':
-        cvm.error(check_result)
->>>>>>> 7af94d1 (modified invite and remove to handle owners)
-=======
-    demote_owner_checks(owner, cvm.tx.key_alias, room)
->>>>>>> 942c14e (more tests/now use @public)
 
     #update the owners list in storage
     otr : str = owner
@@ -764,38 +638,15 @@ def demote_owner_checks(owner: KeyAlias, caller: KeyAlias, room: Room) -> None:
     if not std.contains_using(room.owners, owner, _str_eq):
         owner_str : str = owner
         room_channel_str : str = room_channel
-<<<<<<< HEAD
-<<<<<<< HEAD
         cvm.error(f'{owner_str} is not an owner of room {room_channel_str}. Cannot demote a non-owner')
-=======
-        return f'{owner_str} is not an owner of room {room_channel_str}. Cannot demote a non-owner'
->>>>>>> 7af94d1 (modified invite and remove to handle owners)
-=======
-        cvm.error(f'{owner_str} is not an owner of room {room_channel_str}. Cannot demote a non-owner')
->>>>>>> 942c14e (more tests/now use @public)
     
     #check to ensure that a room is not deleted
     if room.is_deleted:
         room_channel_str : str = room_channel
-<<<<<<< HEAD
-<<<<<<< HEAD
         cvm.error(f'Room {room_channel_str} has been deleted. Cannot demote anyone')
-=======
-        return f'Room {room_channel_str} has been deleted. Cannot promote anyone'
-=======
-        cvm.error(f'Room {room_channel_str} has been deleted. Cannot demote anyone')
->>>>>>> 942c14e (more tests/now use @public)
 
     #cannot leave zero owners in the room
     if len(room.owners) == 1 and len(room.members) == 1:
-<<<<<<< HEAD
-        return f"Cannot demote {owner}, as {owner} is the only member!"
->>>>>>> 7af94d1 (modified invite and remove to handle owners)
-
-    #cannot leave zero owners in the room
-    if len(room.owners) == 1 and len(room.members) == 1:
-=======
->>>>>>> 942c14e (more tests/now use @public)
         cvm.error(f"Cannot demote {owner}, as {owner} is the only member!")
 
 def _str_eq(str1 : str, str2: str) -> bool:

--- a/chat.sympl
+++ b/chat.sympl
@@ -409,6 +409,11 @@ def _remove_from_room_execute(room_channel: ChannelName, member_to_remove: KeyAl
     room = _get_room(room_channel)
     members = room.members
 
+    #check to ensure owner member is not an owner, demote him if possible
+    if std.contains_using(room.owners, member_to_remove, _str_eq):
+        with PostTxArgs(room_channel):
+            _demote_owner_execute(room_channel,member_to_remove)
+
     #run checks on removing
     remove_from_room_checks(room, member_to_remove, cvm.tx.key_alias)
   

--- a/chat.sympl
+++ b/chat.sympl
@@ -146,7 +146,6 @@ def remove_from_room(room_channel: ChannelName, member_to_remove: KeyAlias) -> N
     """
     return _remove_from_room(room_channel, member_to_remove)
 
-
 @clientside
 def get_messages(room_channel: ChannelName) -> List[Message]:
     """Returns all messages in the room, sorted by timestamp."""
@@ -180,7 +179,9 @@ def promote_to_owner(room_channel: ChannelName, member: KeyAlias) -> None:
 @clientside
 def demote_owner(room_channel: ChannelName, owner: KeyAlias) -> None:
     """Demotes the owner of a room.
-    Only works if there is at least one other owner
+    Does not permit the owners list to be left with no owners. If there is only one owner,
+    this will promote another member to owner. If the owner is the only one left in the room,
+    the operation will not be permitted
     """
     return _demote_owner(room_channel, owner)
 
@@ -288,11 +289,12 @@ def _restore_room_execute(room_channel: ChannelName) -> None:
 @public_clientside
 def _invite_to_room(room_channel: ChannelName, new_member: KeyAlias) -> None:
     room = _get_room(room_channel)
-    members = room.members
-    if std.contains_using(members, new_member, _str_eq):
-        new_member_str : str = new_member
-        room_channel_str : str = room_channel
-        cvm.error(f'Member {new_member_str} already in room {room_channel_str}.')
+
+    #perform invite checks
+    check_result : str = invite_to_room_checks(room, new_member, cvm.tx.key_alias)
+    if check_result != '':
+        cvm.error(check_result)
+
     #cvm.add_owner(room_channel, new_member)
     cvm.send_key(room_channel, new_member)
     with PostTxArgs(room_channel):
@@ -305,61 +307,108 @@ def _invite_to_room_execute(room_channel: ChannelName, new_member: KeyAlias) -> 
     room = _get_room(room_channel)
     members = room.members
 
-    if not std.contains_using(members, cvm.tx.key_alias, _str_eq):
-        not_a_member : str = cvm.tx.key_alias
-        cvm.error(f'Member {not_a_member} does not belong to the room. Operation denied.')
-
+    #perform invite checks
+    check_result : str = invite_to_room_checks(room, new_member, cvm.tx.key_alias)
+    if check_result != '':
+        cvm.error(check_result)
+    
     room.members = room.members + [new_member]
     cvm.storage.put(Identifier('room'), room)
     invite_to_room_event = InviteToRoomEvent(room=room, inviter=cvm.tx.key_alias, invitee=new_member)
     cvm.create_event('InviteToRoomEvent', std.json(invite_to_room_event))
     cvm.job_complete(std.json(invite_to_room_event))
 
+#runs checks to see if the caller has the correct permissions to invite the 
+#a new member to a room, returns '' if there are no issues
+def invite_to_room_checks(room: Room, new_member: KeyAlias, caller: KeyAlias) -> str:
+
+    #check if the caller is an owner
+    if not std.contains_using(room.owners, caller, _str_eq):
+        return f"{caller} is not an owner of the room {room.channel}"
+
+    #check if the invitee is already a member
+    if std.contains_using(room.members, new_member, _str_eq):
+        return f"{new_member} is already a member of the room {room.channel}"
+
+    #check if the room is deleted
+    if room.is_deleted:
+        return f"{room.channel} is deleted."
+
+    return ''
+
+
 @public_clientside
 def _remove_from_room(room_channel: ChannelName, member_to_remove: KeyAlias) -> None:
     room = _get_room(room_channel)
-    mrs : str = member_to_remove
-    if mrs == cvm.tx.key_alias:
-        cvm.error(f"Cannot remove self from room.")
-    members = room.members
-    if not std.contains_using(members, member_to_remove, _str_eq):
-        member_to_remove_str : str = member_to_remove
-        room_channel_str : str = room_channel
-        cvm.error(f'Member {member_to_remove_str} not in room {room_channel_str}.')
+    #run checks on removing
+    checks_result = remove_from_room_checks(room, member_to_remove, cvm.tx.key_alias)
+    if checks_result != '':
+        cvm.error(checks_result)
+
+    #if the member to remove is an owner, we want to remove ownership
+    #privileges, and then promote a new owner if there are no
+    #owners left
+    if std.contains_using(room.owners, member_to_remove, _str_eq):
+       _demote_owner(room_channel,member_to_remove)
+
     with PostTxArgs(room_channel):
         _remove_from_room_execute(room_channel, member_to_remove)
-    #cvm.remove_owner(room_channel, member_to_remove)
+
     cvm.rotate_key(room_channel)
-    updated_members = room.members
-    for member in updated_members:
+    for member in room.members:
         mx : str = member
         if mx != member_to_remove:
             cvm.send_key(room_channel, member)
-    cvm.job_start()
-
 
 @executable
-def _remove_from_room_execute(room_channel: ChannelName, member_to_remove: KeyAlias) -> None:
+def _remove_from_room_execute(room_channel: ChannelName, member_to_remove: KeyAlias) -> RemoveFromRoomEvent:
     room = _get_room(room_channel)
     members = room.members
 
-    if not std.contains_using(members, cvm.tx.key_alias, _str_eq):
-        not_a_member : str = cvm.tx.key_alias
-        cvm.error(f'Member {not_a_member} does not belong to the room. Operation denied.')
-
-    if not std.contains_using(members, member_to_remove, _str_eq):
-        member_to_remove_str : str = member_to_remove
-        cvm.error(f'Member {member_to_remove_str} already removed. This may have happened due to a concurrent operation.')
+    #run checks on removing
+    checks_result = remove_from_room_checks(room, member_to_remove, cvm.tx.key_alias)
+    if checks_result != '':
+        cvm.error(checks_result)    
 
     # room.members-remove(member_to_remove)
     mtr: str = member_to_remove
     rmx : List[KeyAlias] = [m for m in room.members if mtr != m]
     room.members = rmx
+
     cvm.storage.put(Identifier('room'), room)
     remove_from_room_event = RemoveFromRoomEvent(room=room, remover=cvm.tx.key_alias, removee=member_to_remove)
     cvm.create_event('RemoveFromRoomEvent', std.json(remove_from_room_event))
-    cvm.job_complete(std.json(remove_from_room_event))
+    return remove_from_room_event
 
+#runs checks to see if the caller has the correct permissions to invite the 
+#a new member to a room, returns '' if there are no issues
+def remove_from_room_checks(room: Room, member_to_remove: KeyAlias, caller: KeyAlias) -> str:
+    #check if caller is an owner and has perms to remove 
+    if (not std.contains_using(room.owners, caller, _str_eq)): # and (str(member_to_remove) != str(caller)):
+        return f"{caller} is not an owner and does not have permission to remove {member_to_remove} from room {room}" 
+    #check if member to remove is actually a member of the room
+    if not std.contains_using(room.members, member_to_remove, _str_eq):
+        return f"{member_to_remove} is not a member of room {room.channel}. Operation Denied."
+    #check if there will be people left in the room once member_to_remove leaves
+    if len(room.members) == 1:
+        return f"Cannot leave a room empty. Please delete the room if you want to get rid of it!"
+    #check if the room is deleted
+    if room.is_deleted:
+        return f"Room {room.channel} is not deleted! Operation Denied."
+
+    #check if caller is the same as the person to remove... cannot remove yourself
+    #### - this is the case because when someone leaves the secure channel, the keys
+    ####   need to change so that the leaving member can no longer decrypt the 
+    ####   information in the secure channel. The keys cannot be rotated if the 
+    ####   member leaving doesn't have permissions to (is not an owner), and if
+    ####   the owner themselves who is leaving tries to rotate (when keys get rotated)
+    ####   the calling 'owner' of the secure channel implicitly knows the new key
+    mtr_str : str = member_to_remove
+    cal_str : str = caller
+    if mtr_str == cal_str:
+        return f"Cannot remove yourself from the room!"
+
+    return ''
 
 @public_clientside
 def _send_message(room_channel: ChannelName, message: str) -> None:
@@ -498,9 +547,25 @@ def _demote_owner(room_channel: ChannelName, owner: KeyAlias) -> None:
     
     room = _get_room(room_channel)
 
+    #run demote checks
     check_result : str = demote_owner_checks(owner, cvm.tx.key_alias, room)
     if check_result != '':
         cvm.error(check_result)
+    
+    #if there's only one owner left when you attempt to demote an owner
+    #promote the next member (that is not a current owner) to owner
+    #an error will be thrown before this function runs if there is only
+    #one member, so we can be sure there are at least two members at
+    #this point
+    if len(room.owners) == 1:
+        members : List[KeyAlias] = room.members
+        new_owner : str = str(members[0])
+        owner_str : str = owner
+        if owner_str == new_owner:
+            new_owner = str(members[1])
+        
+        oka: KeyAlias = KeyAlias(new_owner)
+        _promote_to_owner(room_channel, oka)
 
     #This will remove the 'owner' from the secure channel
     cvm.remove_owner(room_channel, owner)
@@ -514,7 +579,7 @@ def _demote_owner(room_channel: ChannelName, owner: KeyAlias) -> None:
 @executable
 def _demote_owner_execute(room_channel: ChannelName, owner: KeyAlias) -> DemoteOwnerEvent:
     room = _get_room(room_channel)
-    
+
     check_result : str = demote_owner_checks(owner, cvm.tx.key_alias, room)
     if check_result != '':
         cvm.error(check_result)
@@ -525,7 +590,7 @@ def _demote_owner_execute(room_channel: ChannelName, owner: KeyAlias) -> DemoteO
     room.owners = new_owners_list
     cvm.storage.put(Identifier('room'), room)
 
-    #create an event for owner promotion, and return the event data
+    #create an event for owner demotion, and return the event data
     demote_owner_event = DemoteOwnerEvent(room=room, demoter=cvm.tx.key_alias, demotee=owner)
     cvm.create_event('DemoteOwnerEvent', std.json(demote_owner_event))
     return demote_owner_event
@@ -546,7 +611,7 @@ def demote_owner_checks(owner: KeyAlias, caller: KeyAlias, room: Room) -> str:
     if not std.contains_using(room.owners, owner, _str_eq):
         owner_str : str = owner
         room_channel_str : str = room_channel
-        return f'{owner_str} is not an owner of room {room_channel_str}.'
+        return f'{owner_str} is not an owner of room {room_channel_str}. Cannot demote a non-owner'
     
     #check to ensure that a room is not deleted
     if room.is_deleted:
@@ -554,10 +619,14 @@ def demote_owner_checks(owner: KeyAlias, caller: KeyAlias, room: Room) -> str:
         return f'Room {room_channel_str} has been deleted. Cannot promote anyone'
 
     #ensure that the calling key alias is an owner of the room, and is allowed
-    #to promote others to owner
+    #to demote others from owner
     if not std.contains_using(room.owners, caller, _str_eq):
         not_an_owner : str = caller
         return f'{not_an_owner} is not an owner of the room. Operation denied.'
+    
+    #cannot leave zero owners in the room
+    if len(room.owners) == 1 and len(room.members) == 1:
+        return f"Cannot demote {owner}, as {owner} is the only member!"
 
     return ""
 

--- a/chat.sympl
+++ b/chat.sympl
@@ -328,7 +328,7 @@ def invite_to_room_checks(room: Room, new_member: KeyAlias, caller: KeyAlias) ->
 
     #check if the invitee is already a member
     if std.contains_using(room.members, new_member, _str_eq):
-        return f"{new_member} is already a member of the room {room.channel}"
+        return f"Member {new_member} already in room {room.channel}."
 
     #check if the room is deleted
     if room.is_deleted:
@@ -385,10 +385,10 @@ def _remove_from_room_execute(room_channel: ChannelName, member_to_remove: KeyAl
 def remove_from_room_checks(room: Room, member_to_remove: KeyAlias, caller: KeyAlias) -> str:
     #check if caller is an owner and has perms to remove 
     if (not std.contains_using(room.owners, caller, _str_eq)): # and (str(member_to_remove) != str(caller)):
-        return f"{caller} is not an owner and does not have permission to remove {member_to_remove} from room {room}" 
+        return f"{caller} is not an owner and does not have permission to remove {member_to_remove} from room {room.channel}" 
     #check if member to remove is actually a member of the room
     if not std.contains_using(room.members, member_to_remove, _str_eq):
-        return f"{member_to_remove} is not a member of room {room.channel}. Operation Denied."
+        return f"Member {member_to_remove} not in room {room.channel}."
     #check if the room is deleted
     if room.is_deleted:
         return f"Room {room.channel} is not deleted! Operation Denied."
@@ -403,7 +403,7 @@ def remove_from_room_checks(room: Room, member_to_remove: KeyAlias, caller: KeyA
     mtr_str : str = member_to_remove
     cal_str : str = caller
     if mtr_str == cal_str:
-        return f"Cannot remove self from room!"
+        return f"Cannot remove self from room."
 
     return ''
 

--- a/chat.sympl
+++ b/chat.sympl
@@ -182,7 +182,7 @@ def demote_owner(room_channel: ChannelName, owner: KeyAlias) -> None:
     """Demotes the owner of a room.
     Only works if there is at least one other owner
     """
-    return None
+    return _demote_owner(room_channel, owner)
 
 # # ###################
 # # # implementations #
@@ -441,7 +441,7 @@ def _promote_to_owner(room_channel: ChannelName, member: KeyAlias) -> None:
         _promote_to_owner_execute(room_channel, member)
 
 @executable
-def _promote_to_owner_execute(room_channel: ChannelName, member: KeyAlias) -> str:
+def _promote_to_owner_execute(room_channel: ChannelName, member: KeyAlias) -> PromoteToOwnerEvent:
     room = _get_room(room_channel)
     
     #run the checks, and error out if there is an issue
@@ -456,10 +456,10 @@ def _promote_to_owner_execute(room_channel: ChannelName, member: KeyAlias) -> st
     room.owners = room.owners + [member]
     cvm.storage.put(Identifier('room'), room)
 
-    #create an event for owner promotion, and return the json string
+    #create an event for owner promotion, and return the event data
     promote_to_owner_event = PromoteToOwnerEvent(room=room, promoter=cvm.tx.key_alias, promotee=member)
     cvm.create_event('PromoteToOwnerEvent', std.json(promote_to_owner_event))
-    return std.json_to_str(std.json(promote_to_owner_event))
+    return promote_to_owner_event
 
 def promote_to_owner_checks(member: KeyAlias, caller: KeyAlias, room: Room) -> str:
     #This function performs the permission checks for the promote to owner logic
@@ -495,9 +495,12 @@ def promote_to_owner_checks(member: KeyAlias, caller: KeyAlias, room: Room) -> s
 
 @public_clientside
 def _demote_owner(room_channel: ChannelName, owner: KeyAlias) -> None:
-    #Clientside check to make sure that the member to demote is actually
-    #an owner
+    
     room = _get_room(room_channel)
+
+    check_result : str = demote_owner_checks(owner, cvm.tx.key_alias, room)
+    if check_result != '':
+        cvm.error(check_result)
 
     #This will remove the 'owner' from the secure channel
     cvm.remove_owner(room_channel, owner)
@@ -509,19 +512,23 @@ def _demote_owner(room_channel: ChannelName, owner: KeyAlias) -> None:
         _demote_owner_execute(room_channel, owner)
 
 @executable
-def _demote_owner_execute(room_channel: ChannelName, owner: KeyAlias) -> str:
+def _demote_owner_execute(room_channel: ChannelName, owner: KeyAlias) -> DemoteOwnerEvent:
     room = _get_room(room_channel)
     
+    check_result : str = demote_owner_checks(owner, cvm.tx.key_alias, room)
+    if check_result != '':
+        cvm.error(check_result)
+
     #update the owners list in storage
     otr : str = owner
     new_owners_list : List[KeyAlias] = [o for o in room.owners if otr != o]
     room.owners = new_owners_list
     cvm.storage.put(Identifier('room'), room)
 
-    #create an event for owner promotion, and return the json string
+    #create an event for owner promotion, and return the event data
     demote_owner_event = DemoteOwnerEvent(room=room, demoter=cvm.tx.key_alias, demotee=owner)
     cvm.create_event('DemoteOwnerEvent', std.json(demote_owner_event))
-    return std.json_to_str(std.json(demote_owner_event))
+    return demote_owner_event
 
 def demote_owner_checks(owner: KeyAlias, caller: KeyAlias, room: Room) -> str:
     #This function performs the permission checks for the demote owner logic
@@ -535,11 +542,11 @@ def demote_owner_checks(owner: KeyAlias, caller: KeyAlias, room: Room) -> str:
         room_channel_str : str = room_channel
         return f'{owner_str} is not a member of room {room_channel_str}. Please invite them first.'
 
-    #check to ensure the new owner is not already an owner
-    if std.contains_using(room.owners, owner, _str_eq):
+    #check to ensure the owner to demote is actually an owner
+    if not std.contains_using(room.owners, owner, _str_eq):
         owner_str : str = owner
         room_channel_str : str = room_channel
-        return f'{owner_str} is already an owner of room {room_channel_str}.'
+        return f'{owner_str} is not an owner of room {room_channel_str}.'
     
     #check to ensure that a room is not deleted
     if room.is_deleted:

--- a/chat.sympl
+++ b/chat.sympl
@@ -239,6 +239,10 @@ def _delete_room(room_channel: ChannelName) -> None:
 
     with PostTxArgs(room_channel):
         _delete_room_execute(room_channel)
+<<<<<<< HEAD
+=======
+    cvm.job_start()
+>>>>>>> 942c14e (more tests/now use @public)
 
 @executable
 def _delete_room_execute(room_channel: ChannelName) -> DeleteRoomEvent:
@@ -276,6 +280,10 @@ def _restore_room(room_channel: ChannelName) -> None:
 
     with PostTxArgs(room_channel):
         _restore_room_execute(room_channel)
+<<<<<<< HEAD
+=======
+    cvm.job_start()
+>>>>>>> 942c14e (more tests/now use @public)
 
 @executable
 def _restore_room_execute(room_channel: ChannelName) -> RestoreRoomEvent:
@@ -311,12 +319,16 @@ def _invite_to_room(room_channel: ChannelName, new_member: KeyAlias) -> None:
 
     #perform invite checks
 <<<<<<< HEAD
+<<<<<<< HEAD
     invite_to_room_checks(room, new_member, cvm.tx.key_alias)
 =======
     check_result : str = invite_to_room_checks(room, new_member, cvm.tx.key_alias)
     if check_result != '':
         cvm.error(check_result)
 >>>>>>> 7af94d1 (modified invite and remove to handle owners)
+=======
+    invite_to_room_checks(room, new_member, cvm.tx.key_alias)
+>>>>>>> 942c14e (more tests/now use @public)
 
     #cvm.add_owner(room_channel, new_member)
     cvm.send_key(room_channel, new_member)
@@ -331,12 +343,16 @@ def _invite_to_room_execute(room_channel: ChannelName, new_member: KeyAlias) -> 
 
     #perform invite checks
 <<<<<<< HEAD
+<<<<<<< HEAD
     invite_to_room_checks(room, new_member, cvm.tx.key_alias)
 =======
     check_result : str = invite_to_room_checks(room, new_member, cvm.tx.key_alias)
     if check_result != '':
         cvm.error(check_result)
 >>>>>>> 7af94d1 (modified invite and remove to handle owners)
+=======
+    invite_to_room_checks(room, new_member, cvm.tx.key_alias)
+>>>>>>> 942c14e (more tests/now use @public)
     
     room.members = room.members + [new_member]
     cvm.storage.put(Identifier('room'), room)
@@ -344,6 +360,7 @@ def _invite_to_room_execute(room_channel: ChannelName, new_member: KeyAlias) -> 
     invite_to_room_event = InviteToRoomEvent(room=room, inviter=cvm.tx.key_alias, invitee=new_member)
     cvm.create_event('InviteToRoomEvent', std.json(invite_to_room_event))
     return invite_to_room_event
+<<<<<<< HEAD
 
 #runs checks to see if the caller has the correct permissions to invite the 
 #a new member to a room, returns '' if there are no issues
@@ -362,25 +379,30 @@ def invite_to_room_checks(room: Room, new_member: KeyAlias, caller: KeyAlias) ->
     if room.is_deleted:
         cvm.error(f"{room.channel} is deleted.")
 
+=======
+>>>>>>> 942c14e (more tests/now use @public)
 
 @clientside_helper
 #runs checks to see if the caller has the correct permissions to invite the 
 #a new member to a room, returns '' if there are no issues
-def invite_to_room_checks(room: Room, new_member: KeyAlias, caller: KeyAlias) -> str:
+@public
+def invite_to_room_checks(room: Room, new_member: KeyAlias, caller: KeyAlias) -> None:
 
     #check if the caller is an owner
     if not std.contains_using(room.owners, caller, _str_eq):
-        return f"{caller} is not an owner of the room {room.channel}"
+        cvm.error(f"{caller} is not an owner of the room {room.channel}")
 
     #check if the invitee is already a member
     if std.contains_using(room.members, new_member, _str_eq):
+<<<<<<< HEAD
         return f"{new_member} is already a member of the room {room.channel}"
+=======
+        cvm.error(f"Member {new_member} already in room {room.channel}.")
+>>>>>>> 942c14e (more tests/now use @public)
 
     #check if the room is deleted
     if room.is_deleted:
-        return f"{room.channel} is deleted."
-
-    return ''
+        cvm.error(f"{room.channel} is deleted.")
 
 
 @public_clientside
@@ -388,12 +410,16 @@ def _remove_from_room(room_channel: ChannelName, member_to_remove: KeyAlias) -> 
     room = _get_room(room_channel)
     #run checks on removing
 <<<<<<< HEAD
+<<<<<<< HEAD
     remove_from_room_checks(room, member_to_remove, cvm.tx.key_alias)
 =======
     checks_result = remove_from_room_checks(room, member_to_remove, cvm.tx.key_alias)
     if checks_result != '':
         cvm.error(checks_result)
 >>>>>>> 7af94d1 (modified invite and remove to handle owners)
+=======
+    remove_from_room_checks(room, member_to_remove, cvm.tx.key_alias)
+>>>>>>> 942c14e (more tests/now use @public)
 
     #if the member to remove is an owner, we want to remove ownership
     #privileges, and then promote a new owner if there are no
@@ -417,6 +443,7 @@ def _remove_from_room_execute(room_channel: ChannelName, member_to_remove: KeyAl
 
     #run checks on removing
 <<<<<<< HEAD
+<<<<<<< HEAD
     remove_from_room_checks(room, member_to_remove, cvm.tx.key_alias)
   
 =======
@@ -424,6 +451,10 @@ def _remove_from_room_execute(room_channel: ChannelName, member_to_remove: KeyAl
     if checks_result != '':
         cvm.error(checks_result)    
 >>>>>>> 7af94d1 (modified invite and remove to handle owners)
+=======
+    remove_from_room_checks(room, member_to_remove, cvm.tx.key_alias)
+  
+>>>>>>> 942c14e (more tests/now use @public)
 
     # room.members-remove(member_to_remove)
     mtr: str = member_to_remove
@@ -438,6 +469,7 @@ def _remove_from_room_execute(room_channel: ChannelName, member_to_remove: KeyAl
 
 #runs checks to see if the caller has the correct permissions to invite the 
 #a new member to a room, returns '' if there are no issues
+<<<<<<< HEAD
 <<<<<<< HEAD
 @public
 def remove_from_room_checks(room: Room, member_to_remove: KeyAlias, caller: KeyAlias) -> None:
@@ -465,6 +497,19 @@ def remove_from_room_checks(room: Room, member_to_remove: KeyAlias, caller: KeyA
     if room.is_deleted:
         return f"Room {room.channel} is not deleted! Operation Denied."
 >>>>>>> 7af94d1 (modified invite and remove to handle owners)
+=======
+@public
+def remove_from_room_checks(room: Room, member_to_remove: KeyAlias, caller: KeyAlias) -> None:
+    #check if caller is an owner and has perms to remove 
+    if (not std.contains_using(room.owners, caller, _str_eq)): # and (str(member_to_remove) != str(caller)):
+        cvm.error(f"{caller} is not an owner and does not have permission to remove {member_to_remove} from room {room.channel}" )
+    #check if member to remove is actually a member of the room
+    if not std.contains_using(room.members, member_to_remove, _str_eq):
+        cvm.error(f"Member {member_to_remove} not in room {room.channel}.")
+    #check if the room is deleted
+    if room.is_deleted:
+        cvm.error(f"Room {room.channel} is deleted! Operation Denied.")
+>>>>>>> 942c14e (more tests/now use @public)
 
     #check if caller is the same as the person to remove... cannot remove yourself
     #### - this is the case because when someone leaves the secure channel, the keys
@@ -477,12 +522,16 @@ def remove_from_room_checks(room: Room, member_to_remove: KeyAlias, caller: KeyA
     cal_str : str = caller
     if mtr_str == cal_str:
 <<<<<<< HEAD
+<<<<<<< HEAD
         cvm.error(f"Cannot remove self from room.")
 =======
         return f"Cannot remove yourself from the room!"
 
     return ''
 >>>>>>> 7af94d1 (modified invite and remove to handle owners)
+=======
+        cvm.error(f"Cannot remove self from room.")
+>>>>>>> 942c14e (more tests/now use @public)
 
 @clientside_helper
 def _send_message(room_channel: ChannelName, message: str) -> None:
@@ -618,6 +667,7 @@ def _demote_owner(room_channel: ChannelName, owner: KeyAlias) -> None:
 
     #run demote checks
 <<<<<<< HEAD
+<<<<<<< HEAD
     demote_owner_checks(owner, cvm.tx.key_alias, room)
 
 =======
@@ -625,6 +675,10 @@ def _demote_owner(room_channel: ChannelName, owner: KeyAlias) -> None:
     if check_result != '':
         cvm.error(check_result)
 >>>>>>> 7af94d1 (modified invite and remove to handle owners)
+=======
+    demote_owner_checks(owner, cvm.tx.key_alias, room)
+
+>>>>>>> 942c14e (more tests/now use @public)
     
     #if there's only one owner left when you attempt to demote an owner
     #promote the next member (that is not a current owner) to owner
@@ -655,12 +709,16 @@ def _demote_owner_execute(room_channel: ChannelName, owner: KeyAlias) -> DemoteO
     room = _get_room(room_channel)
 
 <<<<<<< HEAD
+<<<<<<< HEAD
     demote_owner_checks(owner, cvm.tx.key_alias, room)
 =======
     check_result : str = demote_owner_checks(owner, cvm.tx.key_alias, room)
     if check_result != '':
         cvm.error(check_result)
 >>>>>>> 7af94d1 (modified invite and remove to handle owners)
+=======
+    demote_owner_checks(owner, cvm.tx.key_alias, room)
+>>>>>>> 942c14e (more tests/now use @public)
 
     #update the owners list in storage
     otr : str = owner
@@ -697,32 +755,37 @@ def demote_owner_checks(owner: KeyAlias, caller: KeyAlias, room: Room) -> None:
         owner_str : str = owner
         room_channel_str : str = room_channel
 <<<<<<< HEAD
+<<<<<<< HEAD
         cvm.error(f'{owner_str} is not an owner of room {room_channel_str}. Cannot demote a non-owner')
 =======
         return f'{owner_str} is not an owner of room {room_channel_str}. Cannot demote a non-owner'
 >>>>>>> 7af94d1 (modified invite and remove to handle owners)
+=======
+        cvm.error(f'{owner_str} is not an owner of room {room_channel_str}. Cannot demote a non-owner')
+>>>>>>> 942c14e (more tests/now use @public)
     
     #check to ensure that a room is not deleted
     if room.is_deleted:
         room_channel_str : str = room_channel
 <<<<<<< HEAD
+<<<<<<< HEAD
         cvm.error(f'Room {room_channel_str} has been deleted. Cannot demote anyone')
 =======
         return f'Room {room_channel_str} has been deleted. Cannot promote anyone'
+=======
+        cvm.error(f'Room {room_channel_str} has been deleted. Cannot demote anyone')
+>>>>>>> 942c14e (more tests/now use @public)
 
-    #ensure that the calling key alias is an owner of the room, and is allowed
-    #to demote others from owner
-    if not std.contains_using(room.owners, caller, _str_eq):
-        not_an_owner : str = caller
-        return f'{not_an_owner} is not an owner of the room. Operation denied.'
-    
     #cannot leave zero owners in the room
     if len(room.owners) == 1 and len(room.members) == 1:
+<<<<<<< HEAD
         return f"Cannot demote {owner}, as {owner} is the only member!"
 >>>>>>> 7af94d1 (modified invite and remove to handle owners)
 
     #cannot leave zero owners in the room
     if len(room.owners) == 1 and len(room.members) == 1:
+=======
+>>>>>>> 942c14e (more tests/now use @public)
         cvm.error(f"Cannot demote {owner}, as {owner} is the only member!")
 
 def _str_eq(str1 : str, str2: str) -> bool:

--- a/chat.sympl
+++ b/chat.sympl
@@ -430,7 +430,7 @@ def _remove_from_room_execute(room_channel: ChannelName, member_to_remove: KeyAl
     return remove_from_room_event
 
 #runs checks to see if the caller has the correct permissions to invite the 
-#a new member to a room, returns '' if there are no issues
+#a new member to a room, throws cvm error if there are issues
 @helper
 def remove_from_room_checks(room: Room, member_to_remove: KeyAlias, caller: KeyAlias) -> None:
     #check if caller is an owner and has perms to remove 
@@ -547,7 +547,7 @@ def _promote_to_owner(room_channel: ChannelName, member: KeyAlias) -> None:
 @executable
 def _promote_to_owner_execute(room_channel: ChannelName, member: KeyAlias) -> PromoteToOwnerEvent:
     room = _get_room(room_channel)
-    
+
     #run the checks, and error out if there is an issue
     #this is performed on both the executable and clientside sides
     #because a malicious KA and Node Administrator could directly run
@@ -601,21 +601,6 @@ def _demote_owner(room_channel: ChannelName, owner: KeyAlias) -> None:
 
     #run demote checks
     demote_owner_checks(owner, cvm.tx.key_alias, room)
-    
-    #if there's only one owner left when you attempt to demote an owner
-    #promote the next member (that is not a current owner) to owner
-    #an error will be thrown before this function runs if there is only
-    #one member, so we can be sure there are at least two members at
-    #this point
-    if len(room.owners) == 1:
-        members : List[KeyAlias] = room.members
-        new_owner : str = str(members[0])
-        owner_str : str = owner
-        if owner_str == new_owner:
-            new_owner = str(members[1])
-        
-        oka: KeyAlias = KeyAlias(new_owner)
-        _promote_to_owner(room_channel, oka)
 
     #This will remove the 'owner' from the secure channel
     cvm.remove_owner(room_channel, owner)
@@ -673,9 +658,11 @@ def demote_owner_checks(owner: KeyAlias, caller: KeyAlias, room: Room) -> None:
         room_channel_str : str = room_channel
         cvm.error(f'Room {room_channel_str} has been deleted. Cannot demote.')
 
-    #cannot leave zero owners in the room
-    if len(room.owners) == 1 and len(room.members) == 1:
-        cvm.error(f"Cannot demote {owner}, as {owner} is the only member!")
+    #cannot demote yourself
+    caller_str : str = caller
+    owner_str : str = owner
+    if caller_str == owner_str:
+        cvm.error(f"Cannot demote yourself!")
 
 def _str_eq(str1 : str, str2: str) -> bool:
     return str1 == str2

--- a/chat.sympl
+++ b/chat.sympl
@@ -74,7 +74,7 @@ schema Room:
     name: str  # the human-readable name of the room
     is_deleted: bool  # to support restoration, deleted rooms are flagged, not expunged
     members: List[KeyAlias]  # a list of the key aliases that have access to the room
-    owners: List[KeyAlias]   # a list of key aliases that are 'owners' of the room (this should always be a subset of 'members', these people functiona as admins)
+    owners: List[KeyAlias]   # a list of key aliases that are 'owners' of the room (this should always be a subset of 'members', these people function as admins)
 
 ##########
 # events #
@@ -332,7 +332,7 @@ def restore_room_checks(room_channel: ChannelName) -> None:
         cvm.error(f'Member {not_a_member} does not belong to the room. Operation denied.')
     if not std.contains_using(room.owners, cvm.tx.key_alias, _str_eq):
         not_an_owner: str = cvm.tx.key_alias
-        cvm.error(f"{not_an_owner} is not an owner and does not have permission to delete the room.")
+        cvm.error(f"{not_an_owner} is not an owner and does not have permission to restore the room.")
 
 @clientside_helper
 def _invite_to_room(room_channel: ChannelName, new_member: KeyAlias) -> None:
@@ -341,7 +341,6 @@ def _invite_to_room(room_channel: ChannelName, new_member: KeyAlias) -> None:
     #perform invite checks
     invite_to_room_checks(room, new_member)
 
-    #cvm.add_owner(room_channel, new_member)
     cvm.send_key(room_channel, new_member)
     with PostTxArgs(room_channel):
         _invite_to_room_execute(room_channel, new_member)

--- a/test/chat_8_3_0_0_coverage_test.py
+++ b/test/chat_8_3_0_0_coverage_test.py
@@ -104,8 +104,8 @@ class TestChatCoverage():
         chat_8('alice').create_room(room_name='room_2')
         rooms = chat_8('alice').get_rooms()
         utils.scrub_channels(rooms)
-        assert rooms == [{'name': 'room_1', 'is_deleted': False, 'members': [store['alice']]},
-                         {'name': 'room_2', 'is_deleted': False, 'members': [store['alice']]}]
+        assert rooms == [{'name': 'room_1', 'is_deleted': False, 'members': [store['alice']], 'owners':[store['alice']]},
+                         {'name': 'room_2', 'is_deleted': False, 'members': [store['alice']], 'owners':[store['alice']]}]
 
     def test_get_rooms_sorted_by_name(self, store, chat_8):
         chat_8('alice').create_room(room_name='room_0')

--- a/test/chat_8_3_0_0_events_test.py
+++ b/test/chat_8_3_0_0_events_test.py
@@ -47,3 +47,16 @@ class TestChatCoverage():
         room = chat_8('alice').create_room(room_name=ROOM_NAME)['room']['channel']
         chat_8('alice').send_message(room_channel=room, message="message")
         assert _is_room_event_present(network.events(), ROOM_NAME, 'SendMessageEvent')
+
+    def test_promote_owner(self, chat_8, network, store):
+        room = chat_8('alice').create_room(room_name=ROOM_NAME)['room']['channel']
+        chat_8('alice').invite_to_room(room_channel=room, new_member=store['bob'])
+        chat_8('alice').promote_to_owner(room_channel=room, member=store['bob'])
+        assert _is_room_event_present(network.events(), ROOM_NAME, 'PromoteToOwnerEvent')
+    
+    def test_demote_owner(self, chat_8, network, store):
+        room = chat_8('alice').create_room(room_name=ROOM_NAME)['room']['channel']
+        chat_8('alice').invite_to_room(room_channel=room, new_member=store['bob'])
+        chat_8('alice').promote_to_owner(room_channel=room, member=store['bob'])
+        chat_8('alice').demote_owner(room_channel=room, member=store['bob'])
+        assert _is_room_event_present(network.events(), ROOM_NAME, 'DemoteOwnerEvent')

--- a/test/chat_8_3_0_0_model_test.py
+++ b/test/chat_8_3_0_0_model_test.py
@@ -111,6 +111,14 @@ class TestRegTests:
         invitee = state.key_alias()
         state.invite_to_room(invitee=invitee, inviter=inviter, room_channel=room)
 
+    def test_invite_non_owner(self, state):
+        inviter = state.key_alias()
+        room = state.create_room(creator=inviter, room_name='room_name')
+        invitee = state.key_alias()
+        state.invite_to_room(invitee=invitee, inviter=inviter, room_channel=room)
+        third = state.key_alias()
+        state.invite_to_room(invitee=third, inviter=invitee, room_channel=room)
+
     def test_invite_user_who_then_deletes_room(self, state):
         deleter = state.key_alias()
         creator = state.key_alias()
@@ -169,6 +177,13 @@ class TestRegTests:
         u1 = state.key_alias()
         room = state.create_room(creator=u1, room_name='0')
         state.delete_room(deleter=u1, room_channel=room)
+
+    def test_create_and_non_owner_delete_room(self, state):
+        u1 = state.key_alias()
+        u2 = state.key_alias()
+        room = state.create_room(creator=u1, room_name='0')
+        state.invite_to_room(inviter=u1, invitee=u2, room_channel=room)
+        state.delete_room(deleter=u2, room_channel=room)
 
     def test_send_message(self, state):
         u1 = state.key_alias()

--- a/test/chat_8_3_0_0_model_test.py
+++ b/test/chat_8_3_0_0_model_test.py
@@ -195,6 +195,29 @@ class TestRegTests:
         invitee = state.key_alias()
         state.invite_to_room(invitee=invitee, inviter=inviter, room_channel=room)
         state.demote_owner(demoter=inviter, demotee=invitee, room_channel=room)
+    
+    def test_demote_non_owner_demote_owner(self, state):
+        u1 = state.key_alias()
+        u2 = state.key_alias()
+        room = state.create_room(creator= u1, room_name="rm1")
+        state.invite_to_room(inviter=u1, room_channel=room, invitee=u2)
+        state.demote_owner(demoter=u2, room_channel=room, demotee=u2)
+    
+    def test_demote_deleted_room(self, state):
+        u1 = state.key_alias()
+        u2 = state.key_alias()
+        room = state.create_room(creator=u1, room_name="rm1")
+        state.invite_to_room(inviter=u1, room_channel=room, invitee=u2)
+        state.promote_to_owner(promoter=u1, room_channel=room, promotee=u2)
+        state.delete_room(deleter=u1, room_channel=room)
+        state.demote_owner(demoter=u1, room_channel=room, demotee=u2)
+
+    def test_demote_non_member_demote(self, state):
+        u = [state.key_alias() for _ in range(3)]
+        room = state.create_room(creator=u[0], room_name="rm1")
+        state.invite_to_room(inviter=u[0], room_channel=room, invitee=u[1])
+        state.promote_to_owner(promoter=u[0], room_channel=room, promotee=u[1])
+        state.demote_owner(demoter=u[2], room_channel=room, demotee=u[0])
 
 @pytest.mark.usefixtures('network')
 @pytest.mark.proptest

--- a/test/chat_8_3_0_0_model_test.py
+++ b/test/chat_8_3_0_0_model_test.py
@@ -39,6 +39,14 @@ class TestRegTests:
         room = state.create_room(creator=u1, room_name='room_name')
         state.restore_room(room, restorer=u1)
 
+    def test_restore_non_owner_deleted_room(self, state):
+        u1 = state.key_alias()
+        u2 = state.key_alias()
+        room = state.create_room(creator=u1, room_name="rm1")
+        state.invite_to_room(inviter=u1, room_channel=room, invitee=u2)
+        state.delete_room(deleter=u1, room_channel=room)
+        state.restore_room(restorer=u2, room_channel=room)
+
     def test_delete_deleted_room(self, state):
         u1 = state.key_alias()
         room = state.create_room(creator=u1, room_name='room_name')
@@ -49,6 +57,13 @@ class TestRegTests:
         creator = state.key_alias()
         room = state.create_room(creator=creator, room_name='room_name')
         state.delete_room(deleter=creator, room_channel=room)
+
+    def test_delete_non_owner_delete_room(self, state):
+        u1 = state.key_alias()
+        u2 = state.key_alias()
+        room = state.create_room(creator=u1, room_name="rm1")
+        state.invite_to_room(inviter=u1, room_channel=room, invitee=u2)
+        state.delete_room(deleter=u2, room_channel=room)
 
     def test_get_messages_from_new_room(self, state):
         creator = state.key_alias()
@@ -166,7 +181,7 @@ class TestRegTests:
         state.send_message(message='0', room_channel=room, sender=u1)
         state.get_messages(getter=u1, room_channel=room)
 
-    def test_promote_owner(self, state):
+    def test_promote_to_owner(self, state):
         inviter = state.key_alias()
         room = state.create_room(creator=inviter, room_name='room_name')
         invitee = state.key_alias()
@@ -181,6 +196,27 @@ class TestRegTests:
         state.promote_to_owner(promoter=inviter, promotee=invitee, room_channel=room)
         state.promote_to_owner(promoter=inviter, promotee=invitee, room_channel=room)
 
+    def test_promote_non_member(self, state):
+        u1 = state.key_alias()
+        u2 = state.key_alias()
+        room = state.create_room(creator=u1, room_name="rm1")
+        state.promote_to_owner(promoter=u1, room_channel=room, promotee=u2)
+    
+    def test_promote_deleted_room(self, state):
+        inviter = state.key_alias()
+        room = state.create_room(creator=inviter, room_name='room_name')
+        invitee = state.key_alias()
+        state.invite_to_room(invitee=invitee, inviter=inviter, room_channel=room)
+        state.delete_room(deleter=inviter, room_channel=room)
+        state.promote_to_owner(promoter=inviter, promotee=invitee, room_channel=room)
+
+    def test_promote_non_owner_promote_member(self, state):
+        u = [state.key_alias() for _ in range(3)]
+        room = state.create_room(creator=u[0], room_name="rm1")
+        state.invite_to_room(inviter=u[0], room_channel=room, invitee=u[1])
+        state.invite_to_room(inviter=u[0], room_channel=room, invitee=u[2])
+        state.promote_to_owner(promoter=u[1], room_channel=room, promotee=u[2])
+
     def test_demote_owner(self, state):
         inviter = state.key_alias()
         room = state.create_room(creator=inviter, room_name='room_name')
@@ -188,6 +224,13 @@ class TestRegTests:
         state.invite_to_room(invitee=invitee, inviter=inviter, room_channel=room)
         state.promote_to_owner(promoter=inviter, promotee=invitee, room_channel=room)
         state.demote_owner(demoter=invitee, demotee=inviter, room_channel=room)
+
+    def test_demote_self_with_members(self, state):
+        u = [state.key_alias() for _ in range(3)]
+        room = state.create_room(creator=u[0], room_name="rm1")
+        state.invite_to_room(inviter=u[0], room_channel=room, invitee=u[1])
+        state.invite_to_room(inviter=u[0], room_channel=room, invitee=u[2])
+        state.demote_owner(demoter=u[0], room_channel=room, demotee=u[0])
 
     def test_demote_non_owner(self, state):
         inviter = state.key_alias()

--- a/test/chat_8_3_0_0_model_test.py
+++ b/test/chat_8_3_0_0_model_test.py
@@ -87,6 +87,14 @@ class TestRegTests:
         room = state.create_room(creator=creator, room_name='room_name')
         state.remove_from_room(removee=non_member, remover=creator, room_channel=room)
 
+    def test_remove_owner(self, state):
+        u1 = state.key_alias()
+        u2 = state.key_alias()
+        room = state.create_room(creator=u1, room_name="rm1")
+        state.invite_to_room(inviter=u1, invitee=u2, room_channel=room)
+        state.promote_to_owner(promoter=u1, promotee=u2, room_channel=room)
+        state.remove_from_room(remover=u2, removee=u1, room_channel=room)
+
     def test_send_message_as_non_member(self, state):
         sender = state.key_alias()
         creator = state.key_alias()

--- a/test/chat_8_3_0_0_model_test.py
+++ b/test/chat_8_3_0_0_model_test.py
@@ -117,6 +117,14 @@ class TestRegTests:
         state.invite_to_room(invitee=u2, inviter=u1, room_channel=room)
         state.remove_from_room(removee=u1, remover=u2, room_channel=room)
 
+    def test_invite_as_non_owner(self, state):
+        u1 = state.key_alias()
+        u2 = state.key_alias()
+        u3 = state.key_alias()
+        room = state.create_room(creator = u1, room_name='rm1')
+        state.invite_to_room(inviter=u1, invitee=u2, room_channel=room)
+        state.invite_to_room(inviter=u2, invitee=u3, room_channel=room)
+
     def test_create_room_with_empty_name(self, state):
         creator = state.key_alias()
         state.create_room(creator=creator, room_name='')
@@ -157,6 +165,29 @@ class TestRegTests:
         room = state.create_room(creator=u1, room_name='0')
         state.send_message(message='0', room_channel=room, sender=u1)
         state.get_messages(getter=u1, room_channel=room)
+
+    def test_promote_owner(self, state):
+        inviter = state.key_alias()
+        room = state.create_room(creator=inviter, room_name='room_name')
+        invitee = state.key_alias()
+        state.invite_to_room(invitee=invitee, inviter=inviter, room_channel=room)
+        state.promote_to_owner(promoter=inviter, promotee=invitee, room_channel=room)
+
+    def test_promote_owner_twice(self, state):
+        inviter = state.key_alias()
+        room = state.create_room(creator=inviter, room_name='room_name')
+        invitee = state.key_alias()
+        state.invite_to_room(invitee=invitee, inviter=inviter, room_channel=room)
+        state.promote_to_owner(promoter=inviter, promotee=invitee, room_channel=room)
+        state.promote_to_owner(promoter=inviter, promotee=invitee, room_channel=room)
+
+    def test_demote_owner(self, state):
+        inviter = state.key_alias()
+        room = state.create_room(creator=inviter, room_name='room_name')
+        invitee = state.key_alias()
+        state.invite_to_room(invitee=invitee, inviter=inviter, room_channel=room)
+        state.promote_to_owner(promoter=inviter, promotee=invitee, room_channel=room)
+        state.demote_owner(demoter=invitee, demotee=inviter, room_channel=room)
 
 
 @pytest.mark.usefixtures('network')

--- a/test/chat_8_3_0_0_model_test.py
+++ b/test/chat_8_3_0_0_model_test.py
@@ -189,6 +189,12 @@ class TestRegTests:
         state.promote_to_owner(promoter=inviter, promotee=invitee, room_channel=room)
         state.demote_owner(demoter=invitee, demotee=inviter, room_channel=room)
 
+    def test_demote_non_owner(self, state):
+        inviter = state.key_alias()
+        room = state.create_room(creator=inviter, room_name='room_name')
+        invitee = state.key_alias()
+        state.invite_to_room(invitee=invitee, inviter=inviter, room_channel=room)
+        state.demote_owner(demoter=inviter, demotee=invitee, room_channel=room)
 
 @pytest.mark.usefixtures('network')
 @pytest.mark.proptest

--- a/test/chat_8_3_0_0_state_machine.py
+++ b/test/chat_8_3_0_0_state_machine.py
@@ -52,9 +52,7 @@ class ChatValidator(RuleBasedStateMachine):
     def assert_results_match(self, method, caller, **kwargs):
         """Calls the method on both the network and the model, and ensures that their return values are the same."""
         network_result = self.try_and_catch(lambda: getattr(self.network[caller].chat[CHAT_VERSION], method)(**kwargs))
-        print(f"network_result: {network_result}")
         model_result = self.try_and_catch(lambda: getattr(self.model, method)(caller, **kwargs))
-        print(f"model_result: {model_result}")
         if isinstance(model_result, (list, )) and len(model_result) > 0 and 'message_id' in model_result[0]:
             assert scrub_ids_and_timestamps(model_result) == scrub_ids_and_timestamps(network_result)
         else:

--- a/test/chat_8_3_0_0_state_machine.py
+++ b/test/chat_8_3_0_0_state_machine.py
@@ -58,7 +58,7 @@ class ChatValidator(RuleBasedStateMachine):
         if isinstance(model_result, (list, )) and len(model_result) > 0 and 'message_id' in model_result[0]:
             assert scrub_ids_and_timestamps(model_result) == scrub_ids_and_timestamps(network_result)
         else:
-            model_result == network_result
+            assert model_result == network_result
         return network_result
 
     # Each of these rules are changing the state of the state machine.
@@ -141,3 +141,13 @@ class ChatValidator(RuleBasedStateMachine):
     @rule(getter=key_aliases)
     def get_rooms(self, getter):
         return self.assert_results_match('get_rooms', getter)
+
+    @rule(room_channel=room_channels, promoter=key_aliases, promotee=key_aliases)
+    def promote_to_owner(self, promoter, room_channel, promotee):
+        assume(room_channel != FATAL_ERROR)
+        return self.assert_results_match('promote_to_owner', promoter, room_channel=room_channel, member=promotee)
+
+    @rule(room_channel=room_channels, demoter=key_aliases, demotee=key_aliases)
+    def demote_owner(self, demoter, room_channel, demotee):
+        assume(room_channel != FATAL_ERROR)
+        return self.assert_results_match('demote_owner', demoter, room_channel=room_channel, owner=demotee)

--- a/test/chat_8_3_0_0_state_machine.py
+++ b/test/chat_8_3_0_0_state_machine.py
@@ -77,6 +77,8 @@ class ChatValidator(RuleBasedStateMachine):
             network_create_room_event = self.network[creator].chat[CHAT_VERSION].create_room(room_name=room_name)
             room_channel = network_create_room_event['room']['channel']
             model_create_room_event = self.model.create_room(creator, room_channel, room_name)
+            print(network_create_room_event)
+            print(model_create_room_event)
             assert network_create_room_event == model_create_room_event
             return room_channel
         except ContractError as network_error:

--- a/test/model/chat_8_3_0_0_model.py
+++ b/test/model/chat_8_3_0_0_model.py
@@ -182,7 +182,7 @@ class ChatModel:
         if restorer not in room.members:
             raise ContractError(f'Member {restorer} does not belong to the room. Operation denied.')
         if restorer not in room.owners:
-            raise ContractError(f"{restorer} is not an owner and does not have permission to delete the room.")
+            raise ContractError(f"{restorer} is not an owner and does not have permission to restore the room.")
         room.restore()
         return RestoreRoomEvent(room).as_data()
 

--- a/test/model/chat_8_3_0_0_model.py
+++ b/test/model/chat_8_3_0_0_model.py
@@ -92,7 +92,7 @@ class SendMessageEvent:
         self.message_id = message_id
 
     def as_data(self):
-        return {'room': self.room.as_data(), 'message_id': self.mid}
+        return {'room': self.room.as_data(), 'message_id': self.message_id}
 
 class PromoteToOwnerEvent:
     def __init__(self, room, promoter, promotee):

--- a/test/model/chat_8_3_0_0_model.py
+++ b/test/model/chat_8_3_0_0_model.py
@@ -232,17 +232,11 @@ class ChatModel:
         if room.is_deleted:
             raise ContractError(f'Room {room_channel} has been deleted. Cannot demote.')
             #cannot leave zero owners in the room
-        if len(room.owners) == 1 and len(room.members) == 1:
-            raise ContractError(f"Cannot demote {owner}, as {owner} is the only member!")
     
-        if len(room.owners) == 1:
-            members = room.members
-            new_owner = members[0]
-            if new_owner == owner:
-                new_owner = members[1]
-
-            self.promote_to_owner(demoter, room_channel, new_owner)
-
+        #cannot demote yourself
+        if demoter == owner:
+            raise ContractError(f"Cannot demote yourself!")
+    
         room.owners.remove(owner)
         
         return DemoteOwnerEvent(room=room, demoter=demoter, demotee=owner).as_data()

--- a/test/model/chat_8_3_0_0_model.py
+++ b/test/model/chat_8_3_0_0_model.py
@@ -21,6 +21,7 @@ class Room:
         self.creator = creator
         self.messages = []
         self.members = [creator]
+        self.owners = [creator]
         self.is_deleted = False
         self.channel = channel
 
@@ -37,7 +38,7 @@ class Room:
         self.is_deleted = False
 
     def as_data(self):
-        return {'name': self.name, 'is_deleted': self.is_deleted, 'members': self.members, 'channel': self.channel}
+        return {'name': self.name, 'is_deleted': self.is_deleted, 'members': self.members, 'owners': self.owners, 'channel': self.channel}
 
 
 class CreateRoomEvent:

--- a/test/model/chat_8_3_0_0_model.py
+++ b/test/model/chat_8_3_0_0_model.py
@@ -87,12 +87,12 @@ class RemoveFromRoomEvent:
 
 
 class SendMessageEvent:
-    def __init__(self, room, message):
+    def __init__(self, room, mid):
         self.room = room
-        self.message = message
+        self.mid = mid
 
     def as_data(self):
-        return {'room': self.room.as_data(), 'message': self.message.as_data()}
+        return {'room': self.room.as_data(), 'mid': self.mid}
 
 class PromoteToOwnerEvent:
     def __init__(self, room, promoter, promotee):
@@ -193,7 +193,7 @@ class ChatModel:
         if chr(0) in message:
             raise ContractError("Message cannot contain null byte.")
         room.add_message(message, sender, message_id, message_timestamp)
-        return SendMessageEvent(room, Message(sender, message, message_id, message_timestamp))
+        return SendMessageEvent(room, message_id)
 
     def get_messages(self, getter, room_channel):
         room = self._get_room(getter, room_channel)

--- a/test/model/chat_8_3_0_0_model.py
+++ b/test/model/chat_8_3_0_0_model.py
@@ -155,7 +155,7 @@ class ChatModel:
         if remover not in room.owners:
             raise ContractError(f"{remover} is not an owner and does not have permission to remove {member_to_remove} from room {room.channel}" )
         if room.is_deleted:
-            raise ContractError(f"Room {room.channel} is not deleted! Operation Denied.")
+            raise ContractError(f"Room {room.channel} is deleted! Operation Denied.")
         if member_to_remove == remover:
             raise ContractError("Cannot remove self from room.")
         room.members.remove(member_to_remove)
@@ -165,6 +165,10 @@ class ChatModel:
         room = self._get_room(deleter, room_channel)
         if room.is_deleted:
             raise ContractError("Room {} already deleted.".format(room_channel))
+        if deleter not in room.members:
+            raise ContractError(f'Member {deleter} does not belong to the room. Operation denied.')
+        if deleter not in room.owners:
+            raise ContractError(f"{deleter} is not an owner and does not have permission to delete the room.")
         room.delete()
         return DeleteRoomEvent(room).as_data()
 


### PR DESCRIPTION
Implemented owner/member of room roles
Members can no longer:
- Invite to room
- Remove from room
- Delete room
- Restore room

Only owners can do these things
Two new actions were added:
- Promote to Owner
- Demote Owner

which can only be done by owners